### PR TITLE
fix: update tooltip type in charts to use TooltipContentProps

### DIFF
--- a/apps/web/src/components/dashboard/MonthlyCategoryBreakdown.tsx
+++ b/apps/web/src/components/dashboard/MonthlyCategoryBreakdown.tsx
@@ -7,7 +7,7 @@
 'use client';
 
 import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
-import type { TooltipProps } from 'recharts';
+import type { TooltipContentProps } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { EXPENSE_CATEGORY_CHART_COLORS } from '@/constants/categories';
 import { calculateExpenseCategoryBreakdown } from '@/lib/dashboard';
@@ -53,7 +53,7 @@ function isBreakdownTooltipPayload(data: unknown): data is BreakdownTooltipPaylo
   );
 }
 
-function ChartTooltip({ active, payload }: TooltipProps<number, string>) {
+function ChartTooltip({ active, payload }: TooltipContentProps<number, string>) {
   if (!active || !payload || payload.length === 0) {
     return null;
   }

--- a/apps/web/src/components/dashboard/YearlyBalanceChart.tsx
+++ b/apps/web/src/components/dashboard/YearlyBalanceChart.tsx
@@ -18,7 +18,7 @@ import {
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { MonthlyDifference } from '@/store/useYearlyDashboardStore';
-import type { TooltipProps } from 'recharts';
+import type { TooltipContentProps } from 'recharts';
 
 const currencyFormatter = new Intl.NumberFormat('ja-JP', {
   style: 'currency',
@@ -53,7 +53,7 @@ function isTooltipPayload(data: unknown): data is TooltipPayload {
   );
 }
 
-function ChartTooltip({ active, payload }: TooltipProps<number, string>) {
+function ChartTooltip({ active, payload }: TooltipContentProps<number, string>) {
   if (!active || !payload || payload.length === 0) {
     return null;
   }


### PR DESCRIPTION
- Changed tooltip type from TooltipProps to TooltipContentProps in MonthlyCategoryBreakdown and YearlyBalanceChart components for better type safety and compatibility with recharts.