### PR TITLE
feat: 入力UIを下部固定アクションバーに変更

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -30,7 +30,7 @@ import { YearlySummaryCards } from '@/components/dashboard/YearlySummaryCards';
 import { YearlyBalanceChart } from '@/components/dashboard/YearlyBalanceChart';
 import { RecurringExpenseList } from '@/components/dashboard/RecurringExpenseList';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Fab, type FabAction } from '@/components/ui/Fab';
+import { BottomActionBar, type BottomAction } from '@/components/layout/BottomActionBar';
 import { Button } from '@/components/ui/button';
 import { HOUSEHOLD_SETTLEMENT_KEY } from '@/lib/validations/settlement';
 import { useAuthStore } from '@/store/useAuthStore';
@@ -372,26 +372,26 @@ export default function Home() {
   const yearlyChartData = useMemo(() => yearlyDifferences, [yearlyDifferences]);
 
   /**
-   * FAB のアクション
+   * 下部アクションバーのアクション
    */
-  const fabActions: FabAction[] = [
+  const bottomActions: BottomAction[] = [
     {
-      label: '支出を記録',
+      label: '支出',
       icon: ShoppingCart,
       onClick: () => openTransactionModal('expense'),
     },
     {
-      label: '収入を記録',
+      label: '収入',
       icon: CircleDollarSign,
       onClick: () => openTransactionModal('income'),
     },
     {
-      label: '立替を記録',
+      label: '立替',
       icon: Handshake,
       onClick: () => openTransactionModal('advance'),
     },
     {
-      label: '精算を記録',
+      label: '精算',
       icon: HandCoins,
       onClick: () =>
         openSettlementModal({
@@ -399,7 +399,7 @@ export default function Home() {
           suggestedDirection: currentUserBalance < 0 ? 'pay' : 'receive',
         }),
     },
-  ] as const;
+  ];
 
   /**
    * ローディング表示
@@ -509,7 +509,7 @@ export default function Home() {
         </Tabs>
       </main>
 
-      <Fab actions={fabActions} />
+      <BottomActionBar actions={bottomActions} />
 
       <ShareJoinCodeModal
         open={isShareModalOpen}

--- a/apps/web/src/components/layout/BottomActionBar.tsx
+++ b/apps/web/src/components/layout/BottomActionBar.tsx
@@ -1,0 +1,62 @@
+/**
+ * 画面下部固定のアクションバー
+ * 支出/収入/立替/精算の入力を1タップで開始できる
+ */
+
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/**
+ * アクションボタンの定義
+ */
+export interface BottomAction {
+  /** 表示ラベル */
+  label: string;
+  /** 表示アイコン */
+  icon: LucideIcon;
+  /** クリック時の処理 */
+  onClick: () => void;
+  /** 無効状態 */
+  disabled?: boolean;
+}
+
+/**
+ * BottomActionBar のプロパティ
+ */
+interface BottomActionBarProps {
+  /** 表示するアクション一覧 */
+  actions: BottomAction[];
+}
+
+/**
+ * 画面下部固定のアクションバー
+ */
+export function BottomActionBar({ actions }: BottomActionBarProps) {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-40 bg-white shadow-[0_-2px_10px_rgba(0,0,0,0.1)]">
+      <div
+        className="flex justify-around items-center h-16 px-2 max-w-5xl mx-auto"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        {actions.map((action) => (
+          <button
+            key={action.label}
+            type="button"
+            onClick={action.onClick}
+            disabled={action.disabled}
+            className={cn(
+              'flex flex-col items-center justify-center flex-1 py-2 text-gray-600 transition-colors',
+              'hover:text-blue-600 active:text-blue-700',
+              'disabled:cursor-not-allowed disabled:opacity-50'
+            )}
+          >
+            <action.icon className="h-6 w-6" />
+            <span className="text-xs mt-1">{action.label}</span>
+          </button>
+        ))}
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- 画面下部に固定のアクションバー（BottomActionBar）を新規作成
- 支出/収入/立替/精算の4ボタンを常時表示
- 従来のFAB（2タップ）から1タップで入力モーダルを開けるように改善

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `apps/web/src/components/layout/BottomActionBar.tsx` | 新規作成 |
| `apps/web/src/app/page.tsx` | FAB → BottomActionBar に置換 |

## Test plan

- [x] 開発サーバーを起動 (`pnpm --filter web dev`)
- [x] 画面下部に4ボタンが常時表示されることを確認
- [x] 各ボタンタップで対応するモーダルが開くことを確認
- [x] モバイルビューでレイアウトが崩れないことを確認
- [x] ビルドが成功することを確認 (`pnpm --filter web build`)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a persistent bottom action bar for quicker entry and replaces the previous FAB.
> 
> - Adds `components/layout/BottomActionBar.tsx` with `BottomAction` API and a 4-button fixed navigation bar
> - Updates `app/page.tsx` to use `BottomActionBar` instead of `Fab`, defining `bottomActions` to open transaction/settlement modals
> - Shortens action labels (e.g., `支出を記録` → `支出`) and removes the extra tap needed by the old FAB
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eaaa1f477776b45782fa479cdbea3d1dc1fdb6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->