### PR TITLE
入力体験・立替精算・定期リマインダーを改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules/
 # Testing
 coverage/
 *.lcov
+apps/web/test-results/
+apps/web/playwright-report/
 
 # Next.js
 .next/
@@ -52,4 +54,3 @@ lerna-debug.log*
 
 # Brainstorming companion scratch (mockups, not committed)
 .superpowers/
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,24 @@ Required keys (set in `apps/web/.env.local`):
 
 Commit `.env.example` with placeholder values for onboarding.
 
+## ローカル開発用テストログイン
+
+ローカルで実データ付きの画面を確認するための仕組み（本番では無効）。
+
+1. `apps/web/.env.local` に以下を設定:
+   - `SUPABASE_SERVICE_ROLE_KEY`（seed 用）
+   - `NEXT_PUBLIC_ENABLE_DEV_LOGIN=true`
+   - `NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL` / `_PASSWORD`, `NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL` / `_PASSWORD`
+2. テストデータを投入: `pnpm --filter web seed:test`（`-- --dry-run` で確認のみ）
+3. `pnpm --filter web dev` で起動し `/auth` を開く
+4. 「テスト太郎でログイン」/「テスト花子でログイン」で即ログイン
+
+**本番安全性**: dev-login は `NEXT_PUBLIC_ENABLE_DEV_LOGIN === 'true'` のときだけ描画される。
+Vercel など本番ではこの変数と資格情報変数を設定しないこと（未設定ならボタンは出ず、資格情報もバンドルされない）。
+
+**テストアカウントの削除**: 不要になったら Supabase ダッシュボードの Authentication からテストユーザー
+（`@example.com`）を削除し、`households` の「テスト世帯」（固定 UUID `00000000-0000-4000-8000-000000000001`）を削除する。
+
 ## MVP Categories (Fixed)
 
 食費, 外食費, 日用品, 医療費, 家具・家電, 子ども, その他

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,7 +4,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # サーバー専用（seed スクリプト等）。絶対に公開しない
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
-# 開発用テストログイン（ローカルのみ true。Vercel など本番では未設定にすること）
+# 開発用テストログイン（ローカルで有効にするには厳密に true。"false"/"1"/"yes" 等は無効。Vercel など本番では未設定にすること）
 NEXT_PUBLIC_ENABLE_DEV_LOGIN=false
 NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL=test-taro@example.com
 NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD=devpassword123

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,12 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# サーバー専用（seed スクリプト等）。絶対に公開しない
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# 開発用テストログイン（ローカルのみ true。Vercel など本番では未設定にすること）
+NEXT_PUBLIC_ENABLE_DEV_LOGIN=false
+NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL=test-taro@example.com
+NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD=devpassword123
+NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL=test-hanako@example.com
+NEXT_PUBLIC_DEV_LOGIN_HANAKO_PASSWORD=devpassword123

--- a/apps/web/e2e/transaction-mobile.spec.ts
+++ b/apps/web/e2e/transaction-mobile.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+
+test('iPhone幅でタップした取引入力欄が正しくフォーカスされる', async ({ page }) => {
+  await page.goto('/');
+
+  const devLogin = page.getByRole('button', { name: 'テスト太郎でログイン' });
+  if (await devLogin.isVisible()) {
+    await devLogin.click();
+  }
+
+  await expect(page.getByRole('tab', { name: '月次ビュー' })).toBeVisible();
+  // Next.js の開発インジケーターが画面右下を覆うことがあるため、
+  // モーダルを開く操作だけは強制し、フォーム内の操作は実際の tap で検証する。
+  await page.locator('nav').getByRole('button', { name: '支出' }).evaluate((button) => {
+    (button as HTMLButtonElement).click();
+  });
+  await expect(page.getByRole('dialog', { name: '取引を登録' })).toBeVisible();
+
+  const fields = [
+    page.getByLabel('金額'),
+    page.getByLabel('日付'),
+    page.getByLabel('メモ'),
+    page.getByLabel('場所（任意）'),
+  ];
+
+  for (const field of fields) {
+    await field.tap();
+    await expect(field).toBeFocused();
+    const box = await field.boundingBox();
+    expect(box?.height).toBeGreaterThanOrEqual(44);
+  }
+
+  await page.getByRole('button', { name: 'キャンセル' }).evaluate((button) => {
+    (button as HTMLButtonElement).click();
+  });
+  await page.locator('nav').getByRole('button', { name: '収入' }).evaluate((button) => {
+    (button as HTMLButtonElement).click();
+  });
+  await expect(page.getByRole('tab', { name: '収入' })).toHaveAttribute('data-state', 'active');
+  await expect(page.getByLabel('金額')).toHaveValue('');
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "seed:test": "tsx scripts/seed-test-data.ts"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "seed:test": "tsx scripts/seed-test-data.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -47,11 +48,13 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.2",
+    "dotenv": "^16.4.7",
     "eslint": "^9",
     "eslint-config-next": "15.5.9",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
+    "tsx": "^4.19.2",
     "typescript": "^5",
     "vitest": "^4.1.8"
   }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  retries: 1,
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'webkit-iphone',
+      use: { ...devices['iPhone 13'] },
+    },
+  ],
+});

--- a/apps/web/scripts/seed-test-data.ts
+++ b/apps/web/scripts/seed-test-data.ts
@@ -152,17 +152,18 @@ async function main() {
   // 4. 取引・精算（テスト世帯ぶんを入れ替え）
   console.log('4. 取引・精算');
   const transactions = [
-    { type: 'expense', amount: 5200, category: 'groceries', occurred_on: daysAgo(2), note: 'スーパー', payer_user_id: taroId, created_by: taroId },
-    { type: 'expense', amount: 3800, category: 'dining', occurred_on: daysAgo(3), note: 'ランチ', payer_user_id: hanakoId, created_by: hanakoId },
-    { type: 'expense', amount: 1500, category: 'daily', occurred_on: daysAgo(5), note: '日用品', payer_user_id: taroId, created_by: taroId },
-    { type: 'expense', amount: 2200, category: 'medical', occurred_on: daysAgo(7), note: '薬', payer_user_id: hanakoId, created_by: hanakoId },
-    { type: 'expense', amount: 18000, category: 'home', occurred_on: daysAgo(10), note: '家電', payer_user_id: taroId, created_by: taroId },
-    { type: 'expense', amount: 4300, category: 'kids', occurred_on: daysAgo(12), note: '子ども用品', payer_user_id: hanakoId, created_by: hanakoId },
-    { type: 'expense', amount: 980, category: 'other', occurred_on: daysAgo(14), note: 'その他', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 5200, category: 'groceries', occurred_on: daysAgo(2), note: 'スーパー', place: 'スーパー田中', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 1800, category: 'groceries', occurred_on: daysAgo(9), note: 'スーパー', place: 'スーパー田中', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 3800, category: 'dining', occurred_on: daysAgo(3), note: 'ランチ', place: '居酒屋ふじ', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 1500, category: 'daily', occurred_on: daysAgo(5), note: '日用品', place: 'ドラッグてらだ', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 2200, category: 'medical', occurred_on: daysAgo(7), note: '薬', place: 'ドラッグてらだ', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 18000, category: 'home', occurred_on: daysAgo(10), note: '家電', place: 'ヨドバシ', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 4300, category: 'kids', occurred_on: daysAgo(12), note: '子ども用品', place: '西松屋', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 980, category: 'other', occurred_on: daysAgo(14), note: 'その他', place: null, payer_user_id: taroId, created_by: taroId },
     { type: 'income', amount: 280000, category: 'salary', occurred_on: daysAgo(1), note: '給料', payer_user_id: taroId, created_by: taroId },
     { type: 'income', amount: 60000, category: 'sideline', occurred_on: daysAgo(6), note: '副業', payer_user_id: hanakoId, created_by: hanakoId },
-    { type: 'advance', amount: 90000, category: 'home', occurred_on: daysAgo(8), note: '家賃立替', payer_user_id: taroId, advance_to_user_id: null, created_by: taroId },
-    { type: 'advance', amount: 7000, category: 'other', occurred_on: daysAgo(4), note: '花子の買い物立替', payer_user_id: taroId, advance_to_user_id: hanakoId, created_by: taroId },
+    { type: 'advance', amount: 90000, category: 'home', occurred_on: daysAgo(8), note: '家賃立替', place: '不動産すずき', payer_user_id: taroId, advance_to_user_id: null, created_by: taroId },
+    { type: 'advance', amount: 7000, category: 'other', occurred_on: daysAgo(4), note: '花子の買い物立替', place: 'コンビニ', payer_user_id: taroId, advance_to_user_id: hanakoId, created_by: taroId },
   ].map((t) => ({ household_id: TEST_HOUSEHOLD_ID, ...t }));
 
   const settlements = [

--- a/apps/web/scripts/seed-test-data.ts
+++ b/apps/web/scripts/seed-test-data.ts
@@ -1,0 +1,190 @@
+/**
+ * テストデータ seed スクリプト（ローカル開発用）
+ *
+ * service role でホスト型 Supabase に「テスト世帯」とテストユーザー2名（夫婦）、
+ * 代表的な取引・精算を冪等に投入する。再実行するとテスト世帯の取引/精算を
+ * 入れ替えて同じ状態に戻す。
+ *
+ * 実行: pnpm --filter web seed:test
+ * 投入内容の確認のみ: pnpm --filter web seed:test -- --dry-run
+ */
+
+import { config } from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const DRY_RUN = process.argv.includes('--dry-run');
+
+/** テスト世帯の固定 UUID（冪等な特定に使用） */
+const TEST_HOUSEHOLD_ID = '00000000-0000-4000-8000-000000000001';
+
+const TARO = {
+  email: process.env.NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL ?? 'test-taro@example.com',
+  password:
+    process.env.NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD ?? 'devpassword123',
+  name: 'テスト太郎',
+};
+const HANAKO = {
+  email:
+    process.env.NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL ?? 'test-hanako@example.com',
+  password:
+    process.env.NEXT_PUBLIC_DEV_LOGIN_HANAKO_PASSWORD ?? 'devpassword123',
+  name: 'テスト花子',
+};
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  console.error(
+    'NEXT_PUBLIC_SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY を .env.local に設定してください'
+  );
+  process.exit(1);
+}
+
+const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+/** メールから既存ユーザーを探し、無ければ作成して id を返す */
+async function ensureUser(account: {
+  email: string;
+  password: string;
+  name: string;
+}): Promise<string> {
+  const { data: list, error: listError } = await admin.auth.admin.listUsers({
+    page: 1,
+    perPage: 1000,
+  });
+  if (listError) throw listError;
+
+  const existing = list.users.find((u) => u.email === account.email);
+  if (existing) {
+    console.log(`  user 既存: ${account.email} (${existing.id})`);
+    return existing.id;
+  }
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email: account.email,
+    password: account.password,
+    email_confirm: true,
+    user_metadata: { name: account.name },
+  });
+  if (error) throw error;
+  console.log(`  user 作成: ${account.email} (${data.user.id})`);
+  return data.user.id;
+}
+
+/** 1日前/数日前などの日付文字列(YYYY-MM-DD)を返す */
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+async function main() {
+  console.log(DRY_RUN ? '[dry-run] 投入内容のプレビュー' : 'seed 開始');
+
+  // 1. ユーザー
+  console.log('1. テストユーザー');
+  if (DRY_RUN) {
+    console.log(`  ${TARO.email} (owner), ${HANAKO.email} (member)`);
+  }
+  const taroId = DRY_RUN ? 'taro-id' : await ensureUser(TARO);
+  const hanakoId = DRY_RUN ? 'hanako-id' : await ensureUser(HANAKO);
+
+  // 2. テスト世帯（固定 UUID で find-or-create）
+  console.log('2. テスト世帯');
+  if (!DRY_RUN) {
+    const { data: hh } = await admin
+      .from('households')
+      .select('id')
+      .eq('id', TEST_HOUSEHOLD_ID)
+      .maybeSingle();
+    if (!hh) {
+      const { error } = await admin.from('households').insert({
+        id: TEST_HOUSEHOLD_ID,
+        name: 'テスト世帯',
+        owner_user_id: taroId,
+      });
+      if (error) throw error;
+      console.log('  世帯 作成: テスト世帯');
+    } else {
+      console.log('  世帯 既存: テスト世帯');
+    }
+
+    // 3. メンバー
+    const { error: memberError } = await admin
+      .from('household_members')
+      .upsert(
+        [
+          {
+            household_id: TEST_HOUSEHOLD_ID,
+            user_id: taroId,
+            role: 'owner',
+          },
+          {
+            household_id: TEST_HOUSEHOLD_ID,
+            user_id: hanakoId,
+            role: 'member',
+          },
+        ],
+        { onConflict: 'household_id,user_id' }
+      );
+    if (memberError) throw memberError;
+    console.log('3. メンバー upsert 完了');
+  }
+
+  // 4. 取引・精算（テスト世帯ぶんを入れ替え）
+  console.log('4. 取引・精算');
+  const transactions = [
+    { type: 'expense', amount: 5200, category: 'groceries', occurred_on: daysAgo(2), note: 'スーパー', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 3800, category: 'dining', occurred_on: daysAgo(3), note: 'ランチ', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 1500, category: 'daily', occurred_on: daysAgo(5), note: '日用品', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 2200, category: 'medical', occurred_on: daysAgo(7), note: '薬', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 18000, category: 'home', occurred_on: daysAgo(10), note: '家電', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 4300, category: 'kids', occurred_on: daysAgo(12), note: '子ども用品', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 980, category: 'other', occurred_on: daysAgo(14), note: 'その他', payer_user_id: taroId, created_by: taroId },
+    { type: 'income', amount: 280000, category: 'salary', occurred_on: daysAgo(1), note: '給料', payer_user_id: taroId, created_by: taroId },
+    { type: 'income', amount: 60000, category: 'sideline', occurred_on: daysAgo(6), note: '副業', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'advance', amount: 90000, category: 'home', occurred_on: daysAgo(8), note: '家賃立替', payer_user_id: taroId, advance_to_user_id: null, created_by: taroId },
+    { type: 'advance', amount: 7000, category: 'other', occurred_on: daysAgo(4), note: '花子の買い物立替', payer_user_id: taroId, advance_to_user_id: hanakoId, created_by: taroId },
+  ].map((t) => ({ household_id: TEST_HOUSEHOLD_ID, ...t }));
+
+  const settlements = [
+    { household_id: TEST_HOUSEHOLD_ID, from_user_id: hanakoId, to_user_id: taroId, amount: 3000, settled_on: daysAgo(1), note: '一部精算', created_by: hanakoId },
+  ];
+
+  if (DRY_RUN) {
+    console.log(`  transactions: ${transactions.length} 件`);
+    console.log(`  settlements: ${settlements.length} 件`);
+    console.log('[dry-run] DB は変更していません');
+    return;
+  }
+
+  const { error: delSettle } = await admin
+    .from('settlements')
+    .delete()
+    .eq('household_id', TEST_HOUSEHOLD_ID);
+  if (delSettle) throw delSettle;
+  const { error: delTx } = await admin
+    .from('transactions')
+    .delete()
+    .eq('household_id', TEST_HOUSEHOLD_ID);
+  if (delTx) throw delTx;
+
+  const { error: txError } = await admin.from('transactions').insert(transactions);
+  if (txError) throw txError;
+  const { error: settleError } = await admin.from('settlements').insert(settlements);
+  if (settleError) throw settleError;
+
+  console.log(
+    `  取引 ${transactions.length} 件 / 精算 ${settlements.length} 件 投入完了`
+  );
+  console.log('seed 完了');
+}
+
+main().catch((err) => {
+  console.error('seed 失敗:', err);
+  process.exit(1);
+});

--- a/apps/web/scripts/seed-test-data.ts
+++ b/apps/web/scripts/seed-test-data.ts
@@ -10,9 +10,12 @@
  */
 
 import { config } from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
 
-config({ path: '.env.local' });
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+config({ path: path.resolve(scriptDir, '..', '.env.local') });
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -47,18 +50,15 @@ const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
 });
 
 /** メールから既存ユーザーを探し、無ければ作成して id を返す */
-async function ensureUser(account: {
-  email: string;
-  password: string;
-  name: string;
-}): Promise<string> {
-  const { data: list, error: listError } = await admin.auth.admin.listUsers({
-    page: 1,
-    perPage: 1000,
-  });
-  if (listError) throw listError;
-
-  const existing = list.users.find((u) => u.email === account.email);
+async function ensureUser(
+  account: {
+    email: string;
+    password: string;
+    name: string;
+  },
+  existingUsers: { id: string; email?: string }[]
+): Promise<string> {
+  const existing = existingUsers.find((u) => u.email === account.email);
   if (existing) {
     console.log(`  user 既存: ${account.email} (${existing.id})`);
     return existing.id;
@@ -79,7 +79,7 @@ async function ensureUser(account: {
 function daysAgo(n: number): string {
   const d = new Date();
   d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 10);
+  return d.toLocaleDateString('sv-SE'); // YYYY-MM-DD（ローカルTZ）
 }
 
 async function main() {
@@ -87,14 +87,28 @@ async function main() {
 
   // 1. ユーザー
   console.log('1. テストユーザー');
+  let taroId: string;
+  let hanakoId: string;
   if (DRY_RUN) {
     console.log(`  ${TARO.email} (owner), ${HANAKO.email} (member)`);
+    taroId = 'taro-id';
+    hanakoId = 'hanako-id';
+  } else {
+    const { data: list, error: listError } = await admin.auth.admin.listUsers({
+      page: 1,
+      perPage: 1000,
+    });
+    if (listError) throw listError;
+    taroId = await ensureUser(TARO, list.users);
+    hanakoId = await ensureUser(HANAKO, list.users);
   }
-  const taroId = DRY_RUN ? 'taro-id' : await ensureUser(TARO);
-  const hanakoId = DRY_RUN ? 'hanako-id' : await ensureUser(HANAKO);
 
   // 2. テスト世帯（固定 UUID で find-or-create）
   console.log('2. テスト世帯');
+  if (DRY_RUN) {
+    console.log('  世帯 find-or-create: テスト世帯 (固定UUID)');
+    console.log('3. メンバー upsert (2件)');
+  }
   if (!DRY_RUN) {
     const { data: hh } = await admin
       .from('households')

--- a/apps/web/src/app/auth/page.tsx
+++ b/apps/web/src/app/auth/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { SignInForm } from '@/components/auth/SignInForm';
 import { SignUpForm } from '@/components/auth/SignUpForm';
+import { DevLoginButton } from '@/components/auth/DevLoginButton';
 
 /**
  * 認証ページコンポーネント
@@ -42,6 +43,7 @@ export default function AuthPage() {
               </CardHeader>
               <CardContent>
                 <SignInForm />
+                <DevLoginButton />
               </CardContent>
             </Card>
           </TabsContent>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
 import { toast } from 'sonner';
 import {
   CircleDollarSign,
@@ -19,17 +20,17 @@ import {
 } from 'lucide-react';
 import { HouseholdSetupCard } from '@/components/household/HouseholdSetupCard';
 import { ShareJoinCodeModal } from '@/components/modals/ShareJoinCodeModal';
-import { TransactionModal } from '@/components/modals/TransactionModal';
+import {
+  TransactionModal,
+  type TransactionModalSource,
+  type TransactionSuccessContext,
+} from '@/components/modals/TransactionModal';
 import { SettlementModal } from '@/components/modals/SettlementModal';
 import { DashboardHeader } from '@/components/layout/DashboardHeader';
 import { MonthlyDashboardView } from '@/components/dashboard/MonthlyDashboardView';
-import { YearlyDashboardView } from '@/components/dashboard/YearlyDashboardView';
-import { RecurringDashboardView } from '@/components/dashboard/RecurringDashboardView';
-import { RecurringIncomeDashboardView } from '@/components/dashboard/RecurringIncomeDashboardView';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { BottomActionBar, type BottomAction } from '@/components/layout/BottomActionBar';
 import { Button } from '@/components/ui/button';
-import { HOUSEHOLD_SETTLEMENT_KEY } from '@/lib/validations/settlement';
 import { formatLocalDate } from '@/lib/utils';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useHouseholdStore } from '@/store/useHouseholdStore';
@@ -40,6 +41,18 @@ import { useYearlyDashboardStore } from '@/store/useYearlyDashboardStore';
 import { useRecurringExpenseStore } from '@/store/useRecurringExpenseStore';
 import { useRecurringIncomeStore } from '@/store/useRecurringIncomeStore';
 import type { Transaction, TransactionType, VariableExpenseReminder, IncomeReminder } from '@/types/transaction';
+
+const YearlyDashboardView = dynamic(() =>
+  import('@/components/dashboard/YearlyDashboardView').then((module) => module.YearlyDashboardView)
+);
+const RecurringDashboardView = dynamic(() =>
+  import('@/components/dashboard/RecurringDashboardView').then((module) => module.RecurringDashboardView)
+);
+const RecurringIncomeDashboardView = dynamic(() =>
+  import('@/components/dashboard/RecurringIncomeDashboardView').then(
+    (module) => module.RecurringIncomeDashboardView
+  )
+);
 
 /**
  * 月をオフセットして YYYY-MM を生成
@@ -103,6 +116,7 @@ export default function Home() {
   const generateFixedTransactions = useRecurringExpenseStore((state) => state.generateFixedTransactions);
   const loadVariableReminders = useRecurringExpenseStore((state) => state.loadVariableReminders);
   const dismissReminder = useRecurringExpenseStore((state) => state.dismissReminder);
+  const completeReminder = useRecurringExpenseStore((state) => state.completeReminder);
 
   const recurringIncomes = useRecurringIncomeStore((state) => state.recurringIncomes);
   const incomeReminders = useRecurringIncomeStore((state) => state.incomeReminders);
@@ -112,17 +126,20 @@ export default function Home() {
   const clearRecurringIncomeError = useRecurringIncomeStore((state) => state.clearError);
   const loadIncomeReminders = useRecurringIncomeStore((state) => state.loadIncomeReminders);
   const dismissIncomeReminder = useRecurringIncomeStore((state) => state.dismissIncomeReminder);
+  const completeIncomeReminder = useRecurringIncomeStore((state) => state.completeIncomeReminder);
 
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const [isTransactionModalOpen, setIsTransactionModalOpen] = useState(false);
-  const [transactionModalType, setTransactionModalType] = useState<TransactionType>('expense');
+  const [transactionModalSource, setTransactionModalSource] = useState<TransactionModalSource>({
+    kind: 'create',
+    type: 'expense',
+  });
   const [isSettlementModalOpen, setIsSettlementModalOpen] = useState(false);
   const [settlementTarget, setSettlementTarget] = useState<{
-    partnerId: string;
-    direction: 'pay' | 'receive';
+    subjectUserId: string;
+    counterpartyUserId: string | null;
   } | null>(null);
   const [activeView, setActiveView] = useState<'monthly' | 'yearly' | 'recurring' | 'recurring-income'>('monthly');
-  const [editingTransaction, setEditingTransaction] = useState<Transaction | undefined>();
   const selectedMonthRef = useRef(selectedMonth);
 
   useEffect(() => {
@@ -288,14 +305,17 @@ export default function Home() {
    * 取引モーダル表示
    */
   const openTransactionModal = (type: TransactionType) => {
-    setTransactionModalType(type);
+    setTransactionModalSource({ kind: 'create', type });
     setIsTransactionModalOpen(true);
   };
 
   /**
    * 取引登録・更新成功時の処理
    */
-  const handleTransactionSuccess = async (transaction: Transaction) => {
+  const handleTransactionSuccess = async (
+    transaction: Transaction,
+    context: TransactionSuccessContext
+  ) => {
     if (!household) {
       return;
     }
@@ -309,28 +329,36 @@ export default function Home() {
     if (transaction.type === 'advance') {
       await loadBalances(household.id);
     }
+
+    if (context.source.kind === 'reminder') {
+      if (context.source.reminderKind === 'expense') {
+        completeReminder(context.source.reminderId);
+        await loadVariableReminders(household.id);
+      } else {
+        completeIncomeReminder(context.source.reminderId);
+        await loadIncomeReminders(household.id);
+      }
+    }
   };
 
   /**
    * リマインダーから支出登録
    */
   const handleRegisterFromReminder = (reminder: VariableExpenseReminder) => {
-    setTransactionModalType('expense');
-    // リマインダーの情報をセットして編集モードのように扱う（プリセット値として）
-    setEditingTransaction({
-      id: '',
-      householdId: household?.id || '',
-      type: 'expense',
-      amount: reminder.amount,
-      occurredOn: formatLocalDate(),
-      category: reminder.category,
-      note: reminder.note,
-      payerUserId: reminder.payerUserId,
-      advanceToUserId: null,
-      place: null,
-      createdBy: user?.id || '',
-      createdAt: '',
-      updatedAt: '',
+    setTransactionModalSource({
+      kind: 'reminder',
+      reminderKind: 'expense',
+      reminderId: reminder.id,
+      preset: {
+        type: 'expense',
+        amount: reminder.amount,
+        occurredOn: formatLocalDate(),
+        category: reminder.category,
+        note: reminder.note,
+        payerUserId: reminder.payerUserId,
+        advanceToUserId: null,
+        place: null,
+      },
     });
     setIsTransactionModalOpen(true);
   };
@@ -339,22 +367,20 @@ export default function Home() {
    * 収入リマインダーから収入登録
    */
   const handleRegisterFromIncomeReminder = (reminder: IncomeReminder) => {
-    setTransactionModalType('income');
-    // リマインダーの情報をセットしてプリセット値として使用
-    setEditingTransaction({
-      id: '',
-      householdId: household?.id || '',
-      type: 'income',
-      amount: reminder.amount,
-      occurredOn: formatLocalDate(),
-      category: reminder.category,
-      note: reminder.note,
-      payerUserId: reminder.recipientUserId,
-      advanceToUserId: null,
-      place: null,
-      createdBy: user?.id || '',
-      createdAt: '',
-      updatedAt: '',
+    setTransactionModalSource({
+      kind: 'reminder',
+      reminderKind: 'income',
+      reminderId: reminder.id,
+      preset: {
+        type: 'income',
+        amount: reminder.amount,
+        occurredOn: formatLocalDate(),
+        category: reminder.category,
+        note: reminder.note,
+        payerUserId: reminder.recipientUserId,
+        advanceToUserId: null,
+        place: null,
+      },
     });
     setIsTransactionModalOpen(true);
   };
@@ -363,7 +389,7 @@ export default function Home() {
    * 取引編集処理
    */
   const handleEditTransaction = (transaction: Transaction) => {
-    setEditingTransaction(transaction);
+    setTransactionModalSource({ kind: 'edit', transaction });
     setIsTransactionModalOpen(true);
   };
 
@@ -396,12 +422,17 @@ export default function Home() {
         await loadBalances(household.id);
       }
 
+      await Promise.all([
+        loadVariableReminders(household.id),
+        loadIncomeReminders(household.id),
+      ]);
+
       if (activeView === 'yearly') {
         await loadYearlySummary(household.id, selectedYear);
       }
     } catch (error) {
       console.error('取引削除エラー:', error);
-      toast.error('取引の削除に失敗しました');
+      // 各ストアの error をページ側の共通通知で一度だけ表示する。
     }
   };
 
@@ -420,19 +451,11 @@ export default function Home() {
     }
   }
 
-  const currentUserBalance =
-    user?.id != null
-      ? balances.find((balance) => balance.userId === user.id)?.balanceAmount ?? 0
-      : 0;
-
-  const openSettlementModal = (target: {
-    partnerId: string;
-    suggestedDirection: 'pay' | 'receive';
+  const openSettlementModal = (target?: {
+    subjectUserId: string;
+    counterpartyUserId: string | null;
   }) => {
-    setSettlementTarget({
-      partnerId: target.partnerId,
-      direction: target.suggestedDirection,
-    });
+    setSettlementTarget(target ?? null);
     setIsSettlementModalOpen(true);
   };
 
@@ -493,11 +516,7 @@ export default function Home() {
     {
       label: '精算',
       icon: HandCoins,
-      onClick: () =>
-        openSettlementModal({
-          partnerId: HOUSEHOLD_SETTLEMENT_KEY,
-          suggestedDirection: currentUserBalance < 0 ? 'pay' : 'receive',
-        }),
+      onClick: () => openSettlementModal(),
     },
   ];
 
@@ -629,14 +648,10 @@ export default function Home() {
         open={isTransactionModalOpen}
         onOpenChange={(open) => {
           setIsTransactionModalOpen(open);
-          if (!open) {
-            setEditingTransaction(undefined);
-          }
         }}
         householdId={household.id}
         members={members}
-        defaultType={transactionModalType}
-        editingTransaction={editingTransaction}
+        source={transactionModalSource}
         onSuccess={handleTransactionSuccess}
       />
 
@@ -644,9 +659,8 @@ export default function Home() {
         open={isSettlementModalOpen}
         onOpenChange={handleSettlementModalOpenChange}
         householdId={household.id}
-        members={members}
-        initialPartnerId={settlementTarget?.partnerId}
-        initialDirection={settlementTarget?.direction}
+        initialSubjectUserId={settlementTarget?.subjectUserId}
+        initialCounterpartyUserId={settlementTarget?.counterpartyUserId}
       />
     </div>
   );

--- a/apps/web/src/components/auth/DevLoginButton.tsx
+++ b/apps/web/src/components/auth/DevLoginButton.tsx
@@ -63,6 +63,7 @@ export function DevLoginButton() {
       router.push('/');
       router.refresh();
     } catch (error) {
+      console.error('テストログインエラー:', error);
       toast.error(
         error instanceof Error ? error.message : 'テストログインに失敗しました'
       );

--- a/apps/web/src/components/auth/DevLoginButton.tsx
+++ b/apps/web/src/components/auth/DevLoginButton.tsx
@@ -1,0 +1,93 @@
+/**
+ * 開発用テストログインボタン
+ *
+ * ローカル開発時のみ表示し、env に設定したテストアカウントで即ログインする。
+ * `NEXT_PUBLIC_ENABLE_DEV_LOGIN === 'true'` のときだけ描画され、
+ * 本番（Vercel 等）では env 未設定のため何も描画されず資格情報もバンドルに残らない。
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { useAuthStore } from '@/store/useAuthStore';
+
+/** テストアカウント定義 */
+interface DevAccount {
+  /** ボタン表示名 */
+  label: string;
+  /** メールアドレス（env から取得・未設定なら undefined） */
+  email?: string;
+  /** パスワード（env から取得・未設定なら undefined） */
+  password?: string;
+}
+
+/**
+ * 開発用テストログインボタン群
+ *
+ * @returns dev-login が有効なときのみボタン群、そうでなければ null
+ */
+export function DevLoginButton() {
+  const router = useRouter();
+  const signIn = useAuthStore((state) => state.signIn);
+  const [loadingLabel, setLoadingLabel] = useState<string | null>(null);
+
+  if (process.env.NEXT_PUBLIC_ENABLE_DEV_LOGIN !== 'true') {
+    return null;
+  }
+
+  const accounts: DevAccount[] = [
+    {
+      label: 'テスト太郎でログイン',
+      email: process.env.NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL,
+      password: process.env.NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD,
+    },
+    {
+      label: 'テスト花子でログイン',
+      email: process.env.NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL,
+      password: process.env.NEXT_PUBLIC_DEV_LOGIN_HANAKO_PASSWORD,
+    },
+  ];
+
+  const handleLogin = async (account: DevAccount) => {
+    if (!account.email || !account.password) {
+      toast.error('テストアカウントの資格情報が未設定です（.env.local を確認）');
+      return;
+    }
+    try {
+      setLoadingLabel(account.label);
+      await signIn(account.email, account.password);
+      toast.success('テストログインしました');
+      router.push('/');
+      router.refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'テストログインに失敗しました'
+      );
+    } finally {
+      setLoadingLabel(null);
+    }
+  };
+
+  return (
+    <div className="mt-6 space-y-2 border-t pt-4">
+      <p className="text-center text-xs text-muted-foreground">
+        開発用テストログイン
+      </p>
+      {accounts.map((account) => (
+        <Button
+          key={account.label}
+          type="button"
+          variant="outline"
+          className="w-full"
+          disabled={loadingLabel !== null}
+          onClick={() => handleLogin(account)}
+        >
+          {loadingLabel === account.label ? 'ログイン中...' : account.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/__tests__/DevLoginButton.test.tsx
+++ b/apps/web/src/components/auth/__tests__/DevLoginButton.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
 import { DevLoginButton } from '../DevLoginButton';
 
 const pushMock = vi.fn();
@@ -75,5 +76,8 @@ describe('DevLoginButton', () => {
     );
 
     expect(signInMock).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      'テストアカウントの資格情報が未設定です（.env.local を確認）'
+    );
   });
 });

--- a/apps/web/src/components/auth/__tests__/DevLoginButton.test.tsx
+++ b/apps/web/src/components/auth/__tests__/DevLoginButton.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DevLoginButton } from '../DevLoginButton';
+
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+const signInMock = vi.fn();
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: (selector: (s: { signIn: typeof signInMock }) => unknown) =>
+    selector({ signIn: signInMock }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe('DevLoginButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signInMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('フラグが未設定なら何も描画しない', () => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_DEV_LOGIN', '');
+    const { container } = render(<DevLoginButton />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('フラグ on で2つのテストログインボタンを描画する', () => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_DEV_LOGIN', 'true');
+    render(<DevLoginButton />);
+    expect(
+      screen.getByRole('button', { name: 'テスト太郎でログイン' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'テスト花子でログイン' })
+    ).toBeInTheDocument();
+  });
+
+  it('ボタンクリックで正しい資格情報で signIn を呼び / に遷移する', async () => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_DEV_LOGIN', 'true');
+    vi.stubEnv('NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL', 'test-taro@example.com');
+    vi.stubEnv('NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD', 'devpassword123');
+    const user = userEvent.setup();
+    render(<DevLoginButton />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'テスト太郎でログイン' })
+    );
+
+    expect(signInMock).toHaveBeenCalledWith(
+      'test-taro@example.com',
+      'devpassword123'
+    );
+    expect(pushMock).toHaveBeenCalledWith('/');
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  it('資格情報が未設定のボタンは signIn を呼ばずエラー通知する', async () => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_DEV_LOGIN', 'true');
+    const user = userEvent.setup();
+    render(<DevLoginButton />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'テスト花子でログイン' })
+    );
+
+    expect(signInMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/dashboard/BalanceCard.tsx
+++ b/apps/web/src/components/dashboard/BalanceCard.tsx
@@ -1,8 +1,4 @@
-/**
- * 立替残高カード
- *
- * 各メンバーの残高と精算ショートカットを表示します。
- */
+/** 相手別の立替残高カード */
 
 'use client';
 
@@ -10,8 +6,7 @@ import { PiggyBank } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { HOUSEHOLD_SETTLEMENT_KEY } from '@/lib/validations/settlement';
-import type { HouseholdBalance } from '@/types/settlement';
+import type { HouseholdBalance, HouseholdBalanceBreakdown } from '@/types/settlement';
 
 const currencyFormatter = new Intl.NumberFormat('ja-JP', {
   style: 'currency',
@@ -19,25 +14,28 @@ const currencyFormatter = new Intl.NumberFormat('ja-JP', {
   maximumFractionDigits: 0,
 });
 
+export interface SettlementTarget {
+  subjectUserId: string;
+  counterpartyUserId: string | null;
+}
+
 interface BalanceCardProps {
   balances: HouseholdBalance[];
   currentUserId?: string;
   isLoading: boolean;
   highlights?: Record<string, boolean>;
-  onSelectSettlementTarget?: (params: {
-    partnerId: string;
-    suggestedDirection: 'pay' | 'receive';
-  }) => void;
+  onSelectSettlementTarget?: (target: SettlementTarget) => void;
 }
 
 function getBalanceClasses(amount: number): string {
-  if (amount > 0) {
-    return 'text-emerald-600';
-  }
-  if (amount < 0) {
-    return 'text-rose-600';
-  }
+  if (amount > 0) return 'text-emerald-600';
+  if (amount < 0) return 'text-rose-600';
   return 'text-gray-500';
+}
+
+function getMemberName(detail: HouseholdBalanceBreakdown, currentUserId?: string): string {
+  if (detail.subjectUserId === currentUserId) return `${detail.subjectUserName || 'あなた'}（あなた）`;
+  return detail.subjectUserName || '名前未設定';
 }
 
 export function BalanceCard({
@@ -47,43 +45,17 @@ export function BalanceCard({
   highlights,
   onSelectSettlementTarget,
 }: BalanceCardProps) {
-  const currentUserBalance =
-    currentUserId != null
-      ? balances.find((balance) => balance.userId === currentUserId)?.balanceAmount ?? 0
-      : 0;
+  const allDetails = balances.flatMap((balance) => balance.breakdowns);
+  const quickTarget =
+    allDetails.find(
+      (detail) => detail.subjectUserId === currentUserId && detail.counterpartyUserId === null
+    ) ?? allDetails.find((detail) => detail.counterpartyUserId === null) ?? allDetails[0];
 
-  const handleHouseholdSettlement = () => {
-    if (!onSelectSettlementTarget) {
-      return;
-    }
-    onSelectSettlementTarget({
-      partnerId: HOUSEHOLD_SETTLEMENT_KEY,
-      suggestedDirection: currentUserBalance < 0 ? 'pay' : 'receive',
+  const openSettlement = (detail: HouseholdBalanceBreakdown) => {
+    onSelectSettlementTarget?.({
+      subjectUserId: detail.subjectUserId,
+      counterpartyUserId: detail.counterpartyUserId,
     });
-  };
-
-  const suggestPartnerForCurrentUser = (direction: 'pay' | 'receive'): string | null => {
-    if (!currentUserId) {
-      return null;
-    }
-
-    const candidates = balances.filter(
-      (balance) => balance.userId && balance.userId !== currentUserId
-    );
-
-    if (direction === 'receive') {
-      return (
-        candidates
-          .filter((balance) => balance.balanceAmount < 0)
-          .sort((a, b) => a.balanceAmount - b.balanceAmount)[0]?.userId ?? null
-      );
-    }
-
-    return (
-      candidates
-        .filter((balance) => balance.balanceAmount > 0)
-        .sort((a, b) => b.balanceAmount - a.balanceAmount)[0]?.userId ?? null
-    );
   };
 
   return (
@@ -91,19 +63,12 @@ export function BalanceCard({
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
         <div>
           <CardTitle>立替残高</CardTitle>
-          <p className="text-sm text-gray-500">
-            プラスは受け取る金額、マイナスは支払う金額です
-          </p>
+          <p className="text-sm text-gray-500">プラスは受け取る、マイナスは支払う金額です</p>
         </div>
         <div className="flex items-center gap-2">
-          {onSelectSettlementTarget && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleHouseholdSettlement}
-            >
-              世帯精算
+          {quickTarget && onSelectSettlementTarget && (
+            <Button type="button" variant="outline" size="sm" className="min-h-11" onClick={() => openSettlement(quickTarget)}>
+              精算する
             </Button>
           )}
           <PiggyBank className="h-6 w-6 text-amber-500" />
@@ -113,103 +78,66 @@ export function BalanceCard({
         {isLoading ? (
           <div className="space-y-3">
             {Array.from({ length: 2 }).map((_, index) => (
-              <div
-                key={index}
-                className="flex items-center justify-between rounded-lg border border-dashed p-3"
-              >
-                <div className="h-4 w-24 animate-pulse rounded bg-gray-200" />
-                <div className="h-4 w-16 animate-pulse rounded bg-gray-200" />
-              </div>
+              <div key={index} className="h-20 animate-pulse rounded-lg border bg-gray-100" />
             ))}
           </div>
         ) : balances.length === 0 ? (
-          <p className="text-sm text-gray-500">まだ立替のやり取りはありません</p>
+          <p className="text-sm text-gray-500">未精算の立替はありません</p>
         ) : (
-          <ul className="space-y-3">
-            {balances.map((balance) => {
-              const isCurrentUser = balance.userId === currentUserId;
-              const isHighlighted = !!highlights?.[balance.userId ?? ''];
-              const displayName =
-                balance.userName || (isCurrentUser ? 'あなた' : '名前未設定');
-              const amountClass = getBalanceClasses(balance.balanceAmount);
-
-              const canSelect = !!onSelectSettlementTarget && !!balance.userId;
-
-              const buttonClassName = cn(
-                'w-full rounded-lg border p-3 text-left ring-0 transition-colors duration-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:cursor-default disabled:opacity-95',
-                canSelect && 'cursor-pointer hover:border-blue-200 hover:bg-blue-50',
-                isCurrentUser && 'border-blue-200 bg-blue-50',
-                isHighlighted && 'border-amber-200 bg-amber-50 ring-2 ring-amber-200'
-              );
-
-              return (
-                <li key={balance.userId ?? displayName}>
-                  <button
-                    type="button"
-                    className={buttonClassName}
-                    disabled={!canSelect}
-                    onClick={() => {
-                      if (!onSelectSettlementTarget || !balance.userId) {
-                        return;
-                      }
-
-                      const direction =
-                        balance.balanceAmount > 0
-                          ? 'receive'
-                          : balance.balanceAmount < 0
-                            ? 'pay'
-                            : 'receive';
-
-                      const partnerId =
-                        isCurrentUser
-                          ? suggestPartnerForCurrentUser(direction) ?? HOUSEHOLD_SETTLEMENT_KEY
-                          : balance.userId;
-
-                      onSelectSettlementTarget({
-                        partnerId: partnerId,
-                        suggestedDirection: direction,
-                      });
-                    }}
-                  >
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="text-sm font-semibold">
-                          {displayName}
-                          {isCurrentUser && (
-                            <span className="ml-2 rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
-                              あなた
+          <ul className="space-y-4">
+            {balances.map((balance) => (
+              <li
+                key={balance.userId}
+                className={cn(
+                  'rounded-lg border p-3 transition-colors',
+                  balance.userId === currentUserId && 'border-blue-200 bg-blue-50',
+                  highlights?.[balance.userId] && 'border-amber-200 bg-amber-50 ring-2 ring-amber-200'
+                )}
+              >
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <p className="text-sm font-semibold">
+                    {balance.breakdowns[0]
+                      ? getMemberName(balance.breakdowns[0], currentUserId)
+                      : balance.userName || '名前未設定'}
+                  </p>
+                  <strong className={getBalanceClasses(balance.balanceAmount)}>
+                    {currencyFormatter.format(balance.balanceAmount)}
+                  </strong>
+                </div>
+                <ul className="space-y-2">
+                  {balance.breakdowns.map((detail) => {
+                    const counterparty = detail.counterpartyUserId
+                      ? detail.counterpartyUserName || '名前未設定'
+                      : '世帯全体';
+                    return (
+                      <li key={`${detail.subjectUserId}:${detail.counterpartyUserId ?? 'household'}`}>
+                        <button
+                          type="button"
+                          className="flex min-h-11 w-full items-center justify-between gap-3 rounded-md border bg-white px-3 py-2 text-left text-sm hover:border-blue-300 hover:bg-blue-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+                          onClick={() => openSettlement(detail)}
+                          disabled={!onSelectSettlementTarget}
+                        >
+                          <span>
+                            {counterparty}
+                            <span className="ml-1 text-xs text-gray-500">
+                              {detail.balanceAmount > 0 ? 'から受け取る' : 'へ支払う'}
                             </span>
-                          )}
-                        </p>
-                        {canSelect && (
-                          <p className="mt-1 text-xs text-blue-600">
-                            {isCurrentUser
-                              ? balance.balanceAmount > 0
-                                ? '受け取った相手との精算を記録'
-                                : balance.balanceAmount < 0
-                                  ? '支払った相手との精算を記録'
-                                  : '精算を記録'
-                              : balance.balanceAmount > 0
-                                ? 'この相手から精算を受け取る'
-                                : balance.balanceAmount < 0
-                                  ? 'この相手へ精算を支払う'
-                                  : '精算を記録'}
-                          </p>
-                        )}
-                      </div>
-                      <div
-                        className={cn(
-                          'text-sm font-semibold transition-all duration-500',
-                          amountClass
-                        )}
-                      >
-                        {currencyFormatter.format(balance.balanceAmount)}
-                      </div>
-                    </div>
-                  </button>
-                </li>
-              );
-            })}
+                            {detail.isOverSettled && (
+                              <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800">
+                                過剰精算の可能性
+                              </span>
+                            )}
+                          </span>
+                          <span className={cn('font-semibold', getBalanceClasses(detail.balanceAmount))}>
+                            {currencyFormatter.format(detail.balanceAmount)}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </li>
+            ))}
           </ul>
         )}
       </CardContent>

--- a/apps/web/src/components/modals/RecurringExpenseModal.tsx
+++ b/apps/web/src/components/modals/RecurringExpenseModal.tsx
@@ -149,19 +149,20 @@ export function RecurringExpenseModal({
     try {
       const recurringExpenseData = toRecurringExpenseData(formData);
 
+      let savedRecurringExpense: RecurringExpense;
       if (isEditMode && editingRecurringExpense) {
-        await updateRecurringExpense(editingRecurringExpense.id, recurringExpenseData);
+        savedRecurringExpense = await updateRecurringExpense(editingRecurringExpense.id, recurringExpenseData);
         toast.success('定期支出を更新しました');
       } else {
-        await addRecurringExpense(recurringExpenseData);
+        savedRecurringExpense = await addRecurringExpense(recurringExpenseData);
         toast.success('定期支出を作成しました');
       }
 
       onOpenChange(false);
-      await onSuccess?.(editingRecurringExpense!);
+      await onSuccess?.(savedRecurringExpense);
     } catch (error) {
       console.error('定期支出保存エラー:', error);
-      toast.error('定期支出の保存に失敗しました');
+      // ストアの error をページ側で一度だけ通知する。
     }
   };
 

--- a/apps/web/src/components/modals/RecurringIncomeModal.tsx
+++ b/apps/web/src/components/modals/RecurringIncomeModal.tsx
@@ -158,7 +158,7 @@ export function RecurringIncomeModal({
       await onSuccess?.(savedRecurringIncome);
     } catch (error) {
       console.error('定期収入保存エラー:', error);
-      toast.error('定期収入の保存に失敗しました');
+      // ストアの error をページ側で一度だけ通知する。
     }
   };
 

--- a/apps/web/src/components/modals/SettlementModal.test.tsx
+++ b/apps/web/src/components/modals/SettlementModal.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettlementModal } from './SettlementModal';
+
+const mocks = vi.hoisted(() => ({ settleBalance: vi.fn() }));
+
+const balances = [
+  {
+    userId: 'user-a',
+    userName: '太郎',
+    balanceAmount: 94000,
+    breakdowns: [
+      {
+        subjectUserId: 'user-a',
+        subjectUserName: '太郎',
+        counterpartyUserId: null,
+        counterpartyUserName: null,
+        balanceAmount: 90000,
+        isOverSettled: false,
+      },
+      {
+        subjectUserId: 'user-a',
+        subjectUserName: '太郎',
+        counterpartyUserId: 'user-b',
+        counterpartyUserName: '花子',
+        balanceAmount: 4000,
+        isOverSettled: false,
+      },
+    ],
+  },
+  {
+    userId: 'user-b',
+    userName: '花子',
+    balanceAmount: 10000,
+    breakdowns: [
+      {
+        subjectUserId: 'user-b',
+        subjectUserName: '花子',
+        counterpartyUserId: null,
+        counterpartyUserName: null,
+        balanceAmount: 10000,
+        isOverSettled: false,
+      },
+    ],
+  },
+];
+
+vi.mock('@/store/useSettlementStore', () => ({
+  useSettlementStore: (selector: (state: unknown) => unknown) =>
+    selector({ balances, settleBalance: mocks.settleBalance, isSubmitting: false }),
+}));
+
+vi.mock('@/lib/hooks/useBodyScrollLock', () => ({ useBodyScrollLock: vi.fn() }));
+
+describe('SettlementModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settleBalance.mockResolvedValue({});
+  });
+
+  it('家族本人でなくても、その家族の世帯向け残高だけを精算できる', async () => {
+    render(
+      <SettlementModal
+        open
+        onOpenChange={vi.fn()}
+        householdId="household-1"
+        initialSubjectUserId="user-b"
+        initialCounterpartyUserId={null}
+      />
+    );
+
+    expect(screen.getByLabelText('精算する残高')).toHaveValue('user-b:__household__');
+    expect(screen.getByLabelText('受け渡した金額')).toHaveValue('10000');
+    expect(screen.getByText('世帯全体から花子が受け取る精算です。')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '精算を記録' }));
+    await waitFor(() =>
+      expect(mocks.settleBalance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subjectUserId: 'user-b',
+          counterpartyUserId: null,
+          amount: 10000,
+        })
+      )
+    );
+  });
+
+  it('世帯向け90,000円と家族間4,000円を別の選択肢として表示する', () => {
+    render(
+      <SettlementModal
+        open
+        onOpenChange={vi.fn()}
+        householdId="household-1"
+        initialSubjectUserId="user-a"
+        initialCounterpartyUserId={null}
+      />
+    );
+    expect(screen.getByLabelText('受け渡した金額')).toHaveValue('90000');
+    expect(screen.getByRole('option', { name: /太郎 × 花子/ })).toHaveTextContent('￥4,000');
+  });
+});

--- a/apps/web/src/components/modals/SettlementModal.tsx
+++ b/apps/web/src/components/modals/SettlementModal.tsx
@@ -1,6 +1,4 @@
-/**
- * 精算記録モーダル
- */
+/** 残高明細に対する精算記録モーダル */
 
 'use client';
 
@@ -19,36 +17,27 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useAuthStore } from '@/store/useAuthStore';
 import { useSettlementStore } from '@/store/useSettlementStore';
-import type { HouseholdMember } from '@/types/household';
 import {
   HOUSEHOLD_SETTLEMENT_KEY,
   settlementSchema,
   type SettlementFormData,
 } from '@/lib/validations/settlement';
+import type { HouseholdBalanceBreakdown } from '@/types/settlement';
 
 interface SettlementModalProps {
-  /** モーダル開閉状態 */
   open: boolean;
-  /** モーダル開閉制御 */
   onOpenChange: (open: boolean) => void;
-  /** 世帯ID */
   householdId: string;
-  /** 世帯メンバー一覧 */
-  members: HouseholdMember[];
-  /** 初期選択するパートナーID */
-  initialPartnerId?: string;
-  /** 初期選択する精算方向 */
-  initialDirection?: 'pay' | 'receive';
+  initialSubjectUserId?: string;
+  initialCounterpartyUserId?: string | null;
 }
 
 function getToday(): string {
   const now = new Date();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  return `${now.getFullYear()}-${month}-${day}`;
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
+    now.getDate()
+  ).padStart(2, '0')}`;
 }
 
 function formatCurrency(amount: number): string {
@@ -59,326 +48,196 @@ function formatCurrency(amount: number): string {
   }).format(amount);
 }
 
+function detailKey(detail: HouseholdBalanceBreakdown): string {
+  return `${detail.subjectUserId}:${detail.counterpartyUserId ?? HOUSEHOLD_SETTLEMENT_KEY}`;
+}
+
+function memberLabel(name: string | null): string {
+  return name || '名前未設定';
+}
+
 export function SettlementModal({
   open,
   onOpenChange,
   householdId,
-  members,
-  initialPartnerId,
-  initialDirection,
+  initialSubjectUserId,
+  initialCounterpartyUserId,
 }: SettlementModalProps) {
-  const currentUser = useAuthStore((state) => state.user);
   const balances = useSettlementStore((state) => state.balances);
-  const addSettlement = useSettlementStore((state) => state.addSettlement);
+  const settleBalance = useSettlementStore((state) => state.settleBalance);
   const isSubmitting = useSettlementStore((state) => state.isSubmitting);
 
-  // モーダルが開いている間、bodyスクロールを無効化
   useBodyScrollLock(open);
 
-  const partnerOptions = useMemo(() => {
-    const householdOption = {
-      value: HOUSEHOLD_SETTLEMENT_KEY,
-      label: '世帯全体',
-    };
+  const details = useMemo(
+    () => balances.flatMap((balance) => balance.breakdowns).filter((detail) => detail.balanceAmount !== 0),
+    [balances]
+  );
 
-    if (!currentUser) {
-      return [householdOption];
-    }
-
-    const memberOptions = members
-      .filter((member) => member.userId !== currentUser.id)
-      .map((member) => ({
-        value: member.userId,
-        label: member.profile?.name || member.profile?.email || '名前未設定',
-      }));
-
-    return [householdOption, ...memberOptions];
-  }, [members, currentUser]);
+  const initialDetail = useMemo(() => {
+    const requested = details.find(
+      (detail) =>
+        detail.subjectUserId === initialSubjectUserId &&
+        detail.counterpartyUserId === (initialCounterpartyUserId ?? null)
+    );
+    return requested ?? details[0];
+  }, [details, initialCounterpartyUserId, initialSubjectUserId]);
 
   const {
     register,
     handleSubmit,
-    setValue,
     reset,
+    setValue,
     watch,
     formState: { errors },
   } = useForm<SettlementFormData>({
     resolver: zodResolver(settlementSchema) as Resolver<SettlementFormData>,
     defaultValues: {
-      direction: 'receive',
-      partnerUserId: HOUSEHOLD_SETTLEMENT_KEY,
-      amount: '' as unknown as number, // 空白表示のため
+      targetKey: '',
+      amount: '' as unknown as number,
       settledOn: getToday(),
       note: '',
     },
   });
 
-  const direction = watch('direction');
-  const partnerUserId = watch('partnerUserId');
+  const targetKey = watch('targetKey');
+  const amount = watch('amount');
+  const selectedDetail = details.find((detail) => detailKey(detail) === targetKey) ?? null;
+  const outstandingAmount = Math.abs(selectedDetail?.balanceAmount ?? 0);
+  const numericAmount = Number.isFinite(Number(amount)) ? Number(amount) : 0;
+  const remainingAmount = Math.max(0, outstandingAmount - numericAmount);
 
-  /**
-   * モーダルを開いたタイミングで初期値を設定
-   */
   useEffect(() => {
-    if (open) {
-      const defaultPartnerId =
-        initialPartnerId ??
-        partnerOptions[0]?.value ??
-        HOUSEHOLD_SETTLEMENT_KEY;
-      const defaultDirection = initialDirection ?? 'receive';
-      reset({
-        direction: defaultDirection,
-        partnerUserId: defaultPartnerId,
-        amount: '' as unknown as number, // 空白表示のため
-        settledOn: getToday(),
-        note: '',
-      });
-    }
-  }, [open, partnerOptions, reset, initialPartnerId, initialDirection]);
+    if (!open) return;
+    reset({
+      targetKey: initialDetail ? detailKey(initialDetail) : '',
+      amount: initialDetail ? Math.abs(initialDetail.balanceAmount) : ('' as unknown as number),
+      settledOn: getToday(),
+      note: '',
+    });
+  }, [initialDetail, open, reset]);
 
-  /**
-   * 相手が存在しない場合はフォームを無効化
-   */
-  const isFormDisabled = !currentUser;
+  const handleTargetChange = (value: string) => {
+    setValue('targetKey', value, { shouldValidate: true });
+    const detail = details.find((item) => detailKey(item) === value);
+    setValue('amount', detail ? Math.abs(detail.balanceAmount) : ('' as unknown as number), {
+      shouldValidate: true,
+    });
+  };
 
-  const currentBalance =
-    balances.find((balance) => balance.userId === currentUser?.id)?.balanceAmount ?? 0;
-
-  const partnerBalance =
-    partnerUserId && partnerUserId !== HOUSEHOLD_SETTLEMENT_KEY
-      ? balances.find((balance) => balance.userId === partnerUserId)?.balanceAmount ?? null
-      : null;
-
-  const partnerLabel = useMemo(() => {
-    if (partnerUserId === HOUSEHOLD_SETTLEMENT_KEY) {
-      return '世帯全体';
-    }
-    const option = partnerOptions.find((item) => item.value === partnerUserId);
-    return option?.label ?? '相手';
-  }, [partnerUserId, partnerOptions]);
-
-  /**
-   * フォーム送信
-   */
   const onSubmit: SubmitHandler<SettlementFormData> = async (data) => {
-    if (!currentUser) {
-      toast.error('ユーザー情報が取得できません');
+    const detail = details.find((item) => detailKey(item) === data.targetKey);
+    if (!detail) {
+      toast.error('精算する残高を選択してください');
       return;
     }
-
-    if (!data.partnerUserId) {
-      toast.error('相手を選択してください');
+    if (data.amount > Math.abs(detail.balanceAmount)) {
+      toast.error('精算額が現在の立替残高を超えています');
       return;
     }
-
-    const isHouseholdSettlement = data.partnerUserId === HOUSEHOLD_SETTLEMENT_KEY;
-
-    const fromUserId =
-      data.direction === 'pay'
-        ? currentUser.id
-        : isHouseholdSettlement
-          ? null
-          : data.partnerUserId;
-    const toUserId =
-      data.direction === 'pay'
-        ? isHouseholdSettlement
-          ? null
-          : data.partnerUserId
-        : currentUser.id;
 
     try {
-      await addSettlement({
+      await settleBalance({
         householdId,
-        fromUserId,
-        toUserId,
+        subjectUserId: detail.subjectUserId,
+        counterpartyUserId: detail.counterpartyUserId,
         amount: data.amount,
         settledOn: data.settledOn,
-        note: data.note?.trim() ? data.note.trim() : null,
+        note: data.note,
       });
-
-      const partnerDescriptor =
-        isHouseholdSettlement ? '世帯全体' : partnerLabel;
-      const actionPhrase =
-        data.direction === 'pay' ? `${partnerDescriptor}へ支払いました` : `${partnerDescriptor}から受け取りました`;
-
       toast.success('精算を記録しました', {
-        description: `${formatCurrency(data.amount)} を${actionPhrase}`,
+        description: `${formatCurrency(data.amount)}・残り ${formatCurrency(
+          Math.abs(detail.balanceAmount) - data.amount
+        )}`,
       });
-
       onOpenChange(false);
     } catch (error) {
       console.error('精算記録エラー:', error);
-      toast.error(error instanceof Error ? error.message : '精算の記録に失敗しました');
+      // ストアの error はページ側で一度だけ通知する。
     }
   };
+
+  const actionDescription = selectedDetail
+    ? selectedDetail.isOverSettled
+      ? '過去の精算額が元の立替残高を超えています。履歴を確認してから精算してください。'
+      : selectedDetail.balanceAmount > 0
+        ? `${selectedDetail.counterpartyUserId ? memberLabel(selectedDetail.counterpartyUserName) : '世帯全体'}から${memberLabel(selectedDetail.subjectUserName)}が受け取る精算です。`
+        : `${memberLabel(selectedDetail.subjectUserName)}が${selectedDetail.counterpartyUserId ? memberLabel(selectedDetail.counterpartyUserName) : '世帯全体'}へ支払う精算です。`
+    : '精算できる立替残高がありません。';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>精算を記録</DialogTitle>
-          <DialogDescription>
-            立替残高に基づいてパートナーや世帯全体との精算を記録します
-          </DialogDescription>
+          <DialogTitle>立替残高を精算</DialogTitle>
+          <DialogDescription>精算する人と相手を選び、受け渡した金額を記録します</DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
-          <Tabs
-            value={direction}
-            onValueChange={(value) =>
-              setValue('direction', value as SettlementFormData['direction'])
-            }
-            className="w-full space-y-5"
-          >
-            <div className="space-y-3">
-              <Label>精算の方向</Label>
-              <TabsList className="w-full">
-                <TabsTrigger value="pay" className="flex-1">
-                  あなたが支払う
-                </TabsTrigger>
-                <TabsTrigger value="receive" className="flex-1">
-                  あなたが受け取る
-                </TabsTrigger>
-              </TabsList>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="partnerUserId">相手</Label>
-              <select
-                id="partnerUserId"
-                className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed"
-                disabled={isSubmitting || isFormDisabled}
-                {...register('partnerUserId')}
-              >
-                <option value="" disabled>
-                  相手を選択してください
+          <div className="space-y-2">
+            <Label htmlFor="settlementTarget">精算する残高</Label>
+            <select
+              id="settlementTarget"
+              className="min-h-11 w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              disabled={isSubmitting || details.length === 0}
+              value={targetKey}
+              onChange={(event) => handleTargetChange(event.target.value)}
+            >
+              {details.length === 0 && <option value="">精算できる残高はありません</option>}
+              {details.map((detail) => (
+                <option key={detailKey(detail)} value={detailKey(detail)}>
+                  {memberLabel(detail.subjectUserName)} × {detail.counterpartyUserId ? memberLabel(detail.counterpartyUserName) : '世帯全体'}（{formatCurrency(detail.balanceAmount)}）
                 </option>
-                {partnerOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-              {errors.partnerUserId && (
-                <p className="text-sm text-red-500">{errors.partnerUserId.message}</p>
-              )}
-              {partnerUserId === HOUSEHOLD_SETTLEMENT_KEY && (
-                <p className="text-xs text-gray-500">
-                  世帯全体への精算として記録され、残高は世帯全員に再配分されます。
-                </p>
-              )}
-            </div>
+              ))}
+            </select>
+            {errors.targetKey && <p className="text-sm text-red-500">{errors.targetKey.message}</p>}
+            <p className="text-sm text-gray-600">{actionDescription}</p>
+          </div>
 
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor="amount">金額</Label>
-                <Input
-                  id="amount"
-                  type="number"
-                  min={1}
-                  step="1"
-                  placeholder="金額を入力"
-                  disabled={isSubmitting || isFormDisabled}
-                  {...register('amount', { valueAsNumber: true })}
-                />
-                {errors.amount && (
-                  <p className="text-sm text-red-500">{errors.amount.message}</p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="settledOn">精算日</Label>
-                <Input
-                  id="settledOn"
-                  type="date"
-                  disabled={isSubmitting || isFormDisabled}
-                  {...register('settledOn')}
-                />
-                {errors.settledOn && (
-                  <p className="text-sm text-red-500">{errors.settledOn.message}</p>
-                )}
-              </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="settlementAmount">受け渡した金額</Label>
+              <Input
+                id="settlementAmount"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9,]*"
+                className="min-h-11 text-base"
+                disabled={isSubmitting || !selectedDetail}
+                {...register('amount')}
+              />
+              {errors.amount && <p className="text-sm text-red-500">{errors.amount.message}</p>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="note">メモ</Label>
-              <textarea
-                id="note"
-                rows={3}
-                className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed"
-                placeholder="任意でメモを入力できます"
-                disabled={isSubmitting}
-                {...register('note')}
-              />
-              {errors.note && (
-                <p className="text-sm text-red-500">{errors.note.message}</p>
-              )}
+              <Label htmlFor="settledOn">精算日</Label>
+              <Input id="settledOn" type="date" className="min-h-11 text-base" disabled={isSubmitting} {...register('settledOn')} />
+              {errors.settledOn && <p className="text-sm text-red-500">{errors.settledOn.message}</p>}
             </div>
-          </Tabs>
+          </div>
 
-          <div className="space-y-2 rounded-lg border border-dashed border-blue-200 bg-blue-50 p-4 text-sm text-blue-700">
-            <p className="font-semibold">現在の立替残高</p>
-            <p className="flex items-baseline gap-2 text-base">
-              <span className="text-gray-600">あなた:</span>
-              <span
-                className={
-                  currentBalance > 0
-                    ? 'font-semibold text-emerald-600'
-                    : currentBalance < 0
-                      ? 'font-semibold text-rose-600'
-                      : 'font-semibold text-gray-700'
-                }
-              >
-                {formatCurrency(currentBalance)}
-              </span>
-            </p>
-            <p className="flex items-baseline gap-2 text-base">
-              <span className="text-gray-600">対象:</span>
-              <span className="font-semibold text-gray-700">{partnerLabel}</span>
-            </p>
-            {partnerBalance !== null && (
-              <p className="flex items-baseline gap-2 text-base">
-                <span className="text-gray-600">残高:</span>
-                <span
-                  className={
-                    partnerBalance > 0
-                      ? 'font-semibold text-emerald-600'
-                      : partnerBalance < 0
-                        ? 'font-semibold text-rose-600'
-                        : 'font-semibold text-gray-700'
-                  }
-                >
-                  {formatCurrency(partnerBalance)}
-                </span>
-              </p>
-            )}
-            {partnerBalance === null && partnerUserId === HOUSEHOLD_SETTLEMENT_KEY && (
-              <p className="text-xs text-blue-600">
-                世帯全体への精算として記録され、他メンバーの残高が再計算されます。
-              </p>
-            )}
-            <p className="text-xs text-blue-600">
-              プラスは受け取る金額、マイナスは支払う金額を意味します。
-            </p>
+          {selectedDetail && (
+            <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800">
+              <div className="flex justify-between"><span>現在残高</span><strong>{formatCurrency(outstandingAmount)}</strong></div>
+              <div className="mt-1 flex justify-between"><span>精算後の残り</span><strong>{formatCurrency(remainingAmount)}</strong></div>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="settlementNote">メモ</Label>
+            <textarea
+              id="settlementNote"
+              rows={3}
+              className="min-h-20 w-full rounded-md border border-gray-200 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              placeholder="任意でメモを入力できます"
+              disabled={isSubmitting}
+              {...register('note')}
+            />
           </div>
 
           <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-              className="flex-1"
-            >
-              キャンセル
-            </Button>
-            <Button
-              type="submit"
-              disabled={isSubmitting || isFormDisabled}
-              className="flex-1"
-            >
-              {isSubmitting ? '記録中...' : '精算を記録'}
-            </Button>
+            <Button type="button" variant="outline" className="min-h-11 flex-1" onClick={() => onOpenChange(false)} disabled={isSubmitting}>キャンセル</Button>
+            <Button type="submit" className="min-h-11 flex-1" disabled={isSubmitting || !selectedDetail}>{isSubmitting ? '保存中...' : '精算を記録'}</Button>
           </div>
         </form>
       </DialogContent>

--- a/apps/web/src/components/modals/TransactionModal.test.tsx
+++ b/apps/web/src/components/modals/TransactionModal.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TransactionModal, type TransactionModalSource } from './TransactionModal';
+import type { Transaction } from '@/types/transaction';
+
+const mocks = vi.hoisted(() => ({
+  addTransaction: vi.fn(),
+  updateTransaction: vi.fn(),
+}));
+
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector({ user: { id: '00000000-0000-4000-8000-000000000001' } }),
+}));
+
+vi.mock('@/store/useTransactionStore', () => ({
+  useTransactionStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      addTransaction: mocks.addTransaction,
+      updateTransaction: mocks.updateTransaction,
+      isSubmitting: false,
+    }),
+}));
+
+vi.mock('@/services/transactions', () => ({
+  getPlaceSuggestions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/lib/hooks/useBodyScrollLock', () => ({ useBodyScrollLock: vi.fn() }));
+
+const member = {
+  id: 'member-1',
+  householdId: 'household-1',
+  userId: '00000000-0000-4000-8000-000000000001',
+  role: 'owner' as const,
+  joinedAt: '2026-07-01T00:00:00Z',
+  profile: { id: '00000000-0000-4000-8000-000000000001', email: 'test@example.com', name: '太郎' },
+};
+
+function savedTransaction(amount: number): Transaction {
+  return {
+    id: 'tx-1',
+    householdId: 'household-1',
+    type: 'expense',
+    amount,
+    occurredOn: '2026-07-28',
+    category: 'groceries',
+    note: null,
+    payerUserId: member.userId,
+    advanceToUserId: null,
+    place: null,
+    recurringExpenseId: null,
+    recurringIncomeId: null,
+    createdBy: member.userId,
+    createdAt: '2026-07-28T00:00:00Z',
+    updatedAt: '2026-07-28T00:00:00Z',
+  };
+}
+
+describe('TransactionModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.addTransaction.mockImplementation(async (data: { amount: number }) =>
+      savedTransaction(data.amount)
+    );
+  });
+
+  it('入力元が変わると描画前に対応する金額へリセットする', () => {
+    const createSource: TransactionModalSource = { kind: 'create', type: 'expense' };
+    const { rerender } = render(
+      <TransactionModal open onOpenChange={vi.fn()} householdId="household-1" members={[member]} source={createSource} />
+    );
+    expect(screen.getByLabelText('金額')).toHaveValue('');
+
+    const reminderSource: TransactionModalSource = {
+      kind: 'reminder',
+      reminderKind: 'expense',
+      reminderId: 'reminder-1',
+      preset: {
+        type: 'expense',
+        amount: 8500,
+        occurredOn: '2026-07-28',
+        category: 'fixed',
+        note: '電気代',
+        payerUserId: member.userId,
+        advanceToUserId: null,
+        place: null,
+      },
+    };
+    rerender(
+      <TransactionModal open onOpenChange={vi.fn()} householdId="household-1" members={[member]} source={reminderSource} />
+    );
+    expect(screen.getByLabelText('金額')).toHaveValue('8500');
+    expect(screen.getByLabelText('メモ')).toHaveValue('電気代');
+  });
+
+  it('登録して続けると日付等を維持し、金額・メモ・場所だけを空にする', async () => {
+    const source: TransactionModalSource = { kind: 'create', type: 'expense' };
+    render(
+      <TransactionModal open onOpenChange={vi.fn()} householdId="household-1" members={[member]} source={source} />
+    );
+
+    fireEvent.change(screen.getByLabelText('金額'), { target: { value: '1200' } });
+    fireEvent.change(screen.getByLabelText('メモ'), { target: { value: 'ランチ' } });
+    fireEvent.change(screen.getByLabelText('場所（任意）'), { target: { value: '食堂' } });
+    fireEvent.click(screen.getByRole('button', { name: '登録して続ける' }));
+
+    await waitFor(() => expect(mocks.addTransaction).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByLabelText('金額')).toHaveValue(''));
+    expect(screen.getByLabelText('メモ')).toHaveValue('');
+    expect(screen.getByLabelText('場所（任意）')).toHaveValue('');
+    expect(screen.getByRole('status')).toHaveTextContent('1,200円を登録しました');
+  });
+});

--- a/apps/web/src/components/modals/TransactionModal.tsx
+++ b/apps/web/src/components/modals/TransactionModal.tsx
@@ -1,15 +1,14 @@
-/**
- * 取引登録モーダル
- */
+/** 取引登録・編集モーダル */
 
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useLayoutEffect, useMemo, useState } from 'react';
 import { Controller, type Resolver, type SubmitHandler, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { toast } from 'sonner';
+import { CheckCircle2 } from 'lucide-react';
 import { useBodyScrollLock } from '@/lib/hooks/useBodyScrollLock';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Dialog,
   DialogContent,
@@ -21,8 +20,15 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { AmountCalculatorPopover } from '@/components/transactions/AmountCalculatorPopover';
+import { CurrencyInput } from '@/components/transactions/CurrencyInput';
+import { PlaceCombobox } from '@/components/transactions/PlaceCombobox';
 import type { HouseholdMember } from '@/types/household';
-import type { Transaction, TransactionType } from '@/types/transaction';
+import type {
+  PlaceSuggestion,
+  Transaction,
+  TransactionCategoryKey,
+  TransactionType,
+} from '@/types/transaction';
 import {
   transactionSchema,
   type TransactionFormData,
@@ -33,29 +39,44 @@ import { getPlaceSuggestions } from '@/services/transactions';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useTransactionStore } from '@/store/useTransactionStore';
 
-/**
- * モーダルのプロパティ
- */
-interface TransactionModalProps {
-  /** モーダル開閉状態 */
-  open: boolean;
-  /** モーダルの開閉を制御するコールバック */
-  onOpenChange: (open: boolean) => void;
-  /** 世帯ID */
-  householdId: string;
-  /** 世帯メンバー一覧 */
-  members: HouseholdMember[];
-  /** デフォルトの取引タイプ */
-  defaultType?: TransactionType;
-  /** 編集対象の取引（編集モード） */
-  editingTransaction?: Transaction;
-  /** 取引作成成功時のコールバック */
-  onSuccess?: (transaction: Transaction) => Promise<void> | void;
+export interface TransactionPreset {
+  type: TransactionType;
+  amount: number;
+  occurredOn: string;
+  category: TransactionCategoryKey;
+  note: string | null;
+  payerUserId: string | null;
+  advanceToUserId: string | null;
+  place: string | null;
 }
 
-/**
- * 今日の日付を YYYY-MM-DD 形式で取得
- */
+export type TransactionModalSource =
+  | { kind: 'create'; type: TransactionType }
+  | { kind: 'edit'; transaction: Transaction }
+  | {
+      kind: 'reminder';
+      reminderKind: 'expense' | 'income';
+      reminderId: string;
+      preset: TransactionPreset;
+    };
+
+export interface TransactionSuccessContext {
+  intent: 'close' | 'continue';
+  source: TransactionModalSource;
+}
+
+interface TransactionModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  householdId: string;
+  members: HouseholdMember[];
+  source: TransactionModalSource;
+  onSuccess?: (
+    transaction: Transaction,
+    context: TransactionSuccessContext
+  ) => Promise<void> | void;
+}
+
 function getToday(): string {
   const now = new Date();
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
@@ -63,40 +84,57 @@ function getToday(): string {
   ).padStart(2, '0')}`;
 }
 
-/**
- * 会員名の表示
- */
 function getMemberLabel(member: HouseholdMember): string {
   return member.profile?.name || member.profile?.email || '名前未設定';
 }
 
-/**
- * 取引登録モーダル
- */
+function getTypeLabel(type: TransactionType): string {
+  if (type === 'income') return '収入';
+  if (type === 'advance') return '立替';
+  return '支出';
+}
+
 export function TransactionModal({
   open,
   onOpenChange,
   householdId,
   members,
-  defaultType = 'expense',
-  editingTransaction,
+  source,
   onSuccess,
 }: TransactionModalProps) {
   const currentUser = useAuthStore((state) => state.user);
   const addTransaction = useTransactionStore((state) => state.addTransaction);
   const updateTransaction = useTransactionStore((state) => state.updateTransaction);
   const isSubmitting = useTransactionStore((state) => state.isSubmitting);
+  const formId = useId();
+  const [placeSuggestions, setPlaceSuggestions] = useState<PlaceSuggestion[]>([]);
+  const [savedMessage, setSavedMessage] = useState<string | null>(null);
 
-  // モーダルが開いている間、bodyスクロールを無効化
   useBodyScrollLock(open);
 
-  // 編集モードかどうか（リマインダーの仮データは除外）
-  const isEditMode = Boolean(editingTransaction?.id);
+  const isEditMode = source.kind === 'edit';
+  const locksType = source.kind !== 'create';
+  const sourceType =
+    source.kind === 'create'
+      ? source.type
+      : source.kind === 'edit'
+        ? source.transaction.type
+        : source.preset.type;
 
-  const getDefaultCategoryForType = (type: TransactionType) => {
-    const categories = getCategoriesByType(type);
-    return categories[0]?.key ?? getCategoriesByType('expense')[0]?.key ?? 'other';
-  };
+  const getDefaultCategoryForType = (type: TransactionType): TransactionCategoryKey =>
+    getCategoriesByType(type)[0]?.key ?? 'other';
+
+  const emptyDefaults = (type: TransactionType): TransactionFormData => ({
+    type,
+    amount: '' as unknown as number,
+    occurredOn: getToday(),
+    category: getDefaultCategoryForType(type),
+    note: '',
+    place: '',
+    isHouseholdAdvance: false,
+    payerUserId: type === 'income' ? null : currentUser?.id ?? null,
+    advanceToUserId: null,
+  });
 
   const {
     control,
@@ -108,405 +146,231 @@ export function TransactionModal({
     formState: { errors },
   } = useForm<TransactionFormData>({
     resolver: zodResolver(transactionSchema) as Resolver<TransactionFormData>,
-    defaultValues: {
-      type: defaultType,
-      amount: '' as unknown as number, // 空白表示のため
-      occurredOn: getToday(),
-      category: getDefaultCategoryForType(defaultType),
-      note: '',
-      place: '',
-      isHouseholdAdvance: false,
-      payerUserId:
-        defaultType === 'expense' || defaultType === 'advance'
-          ? currentUser?.id ?? null
-          : null,
-      advanceToUserId: null,
-    },
+    defaultValues: emptyDefaults(sourceType),
   });
 
   const transactionType = watch('type');
   const payerUserId = watch('payerUserId');
   const category = watch('category');
   const isHouseholdAdvance = watch('isHouseholdAdvance');
-  const [placeSuggestions, setPlaceSuggestions] = useState<string[]>([]);
   const categoriesForType = useMemo(
     () => getCategoriesByType(transactionType),
     [transactionType]
   );
 
-  /**
-   * モーダルを開くたびに初期値をリセット
-   */
-  useEffect(() => {
-    if (open) {
-      if (editingTransaction) {
-        // 編集モード or リマインダーからのプリセット
-        reset({
-          type: editingTransaction.type,
-          amount: editingTransaction.amount,
-          occurredOn: editingTransaction.occurredOn,
-          category: editingTransaction.category ?? getDefaultCategoryForType(editingTransaction.type),
-          note: editingTransaction.note ?? '',
-          place: editingTransaction.place ?? '',
-          isHouseholdAdvance: false, // 立替フラグはフォームでのみ使用
-          payerUserId: editingTransaction.payerUserId,
-          advanceToUserId: editingTransaction.advanceToUserId,
-        });
-      } else {
-        // 新規作成モード
-        reset({
-          type: defaultType,
-          amount: '' as unknown as number, // 空白表示のため
-          occurredOn: getToday(),
-          category: getDefaultCategoryForType(defaultType),
-          note: '',
-          place: '',
-          isHouseholdAdvance: false,
-          payerUserId:
-            defaultType === 'expense' || defaultType === 'advance'
-              ? currentUser?.id ?? null
-              : null,
-          advanceToUserId: null,
-        });
-      }
-    }
-  }, [open, defaultType, reset, currentUser?.id, editingTransaction]);
+  // 開く前の描画フレームで初期化し、以前の入力値が一瞬見えるのを防ぐ。
+  useLayoutEffect(() => {
+    if (!open) return;
+    setSavedMessage(null);
 
-  /**
-   * モーダルオープン時に過去の場所をサジェスト用に読み込む
-   */
-  useEffect(() => {
-    if (open && householdId) {
-      getPlaceSuggestions(householdId)
-        .then(setPlaceSuggestions)
-        .catch(() => setPlaceSuggestions([]));
+    if (source.kind === 'create') {
+      reset(emptyDefaults(source.type));
+      return;
     }
+
+    const preset = source.kind === 'edit' ? source.transaction : source.preset;
+    reset({
+      type: preset.type,
+      amount: preset.amount,
+      occurredOn: preset.occurredOn,
+      category: preset.category ?? getDefaultCategoryForType(preset.type),
+      note: preset.note ?? '',
+      place: preset.place ?? '',
+      isHouseholdAdvance: false,
+      payerUserId: preset.payerUserId,
+      advanceToUserId: preset.advanceToUserId,
+    });
+    // source が変わるたびに必ず別のフォーム内容として扱う。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, reset, source]);
+
+  useEffect(() => {
+    if (!open || !householdId) return;
+    getPlaceSuggestions(householdId).then(setPlaceSuggestions).catch(() => setPlaceSuggestions([]));
   }, [open, householdId]);
 
-  /**
-   * 立替以外では advanceToUserId をクリア
-   */
   useEffect(() => {
-    if (transactionType !== 'advance') {
-      setValue('advanceToUserId', null);
-    }
+    if (transactionType !== 'advance') setValue('advanceToUserId', null);
     if (transactionType !== 'expense' && isHouseholdAdvance) {
       setValue('isHouseholdAdvance', false);
     }
-  }, [transactionType, isHouseholdAdvance, setValue]);
+  }, [isHouseholdAdvance, setValue, transactionType]);
 
-  /**
-   * 取引タイプに応じてカテゴリを補正
-   */
   useEffect(() => {
     if (!categoriesForType.some((item) => item.key === category) && categoriesForType[0]) {
       setValue('category', categoriesForType[0].key);
     }
   }, [categoriesForType, category, setValue]);
 
-  /**
-   * フォーム送信
-   */
-  const onSubmit: SubmitHandler<TransactionFormData> = async (data) => {
+  const save = (intent: 'close' | 'continue'): SubmitHandler<TransactionFormData> => async (data) => {
     try {
-      let transaction: Transaction;
-
-      if (isEditMode && editingTransaction) {
-        // 編集モード
-        transaction = await updateTransaction(editingTransaction.id, toTransactionData(data, householdId));
-        toast.success('取引を更新しました', {
-          description: `${getTypeLabel(transaction.type)}: ¥${transaction.amount.toLocaleString()}`,
-        });
-      } else {
-        // 新規作成モード
-        transaction = await addTransaction(toTransactionData(data, householdId));
-        toast.success('取引を登録しました', {
-          description: `${getTypeLabel(transaction.type)}: ¥${transaction.amount.toLocaleString()}`,
-        });
+      const transactionData = toTransactionData(data, householdId);
+      if (source.kind === 'reminder') {
+        transactionData.recurringExpenseId =
+          source.reminderKind === 'expense' ? source.reminderId : null;
+        transactionData.recurringIncomeId =
+          source.reminderKind === 'income' ? source.reminderId : null;
       }
 
-      if (onSuccess) {
-        await onSuccess(transaction);
+      const transaction =
+        source.kind === 'edit'
+          ? await updateTransaction(source.transaction.id, transactionData)
+          : await addTransaction(transactionData);
+
+      await onSuccess?.(transaction, { intent, source });
+
+      if (intent === 'continue' && source.kind === 'create') {
+        reset({
+          ...data,
+          amount: '' as unknown as number,
+          note: '',
+          place: '',
+        });
+        setSavedMessage(`${getTypeLabel(transaction.type)} ${transaction.amount.toLocaleString()}円を登録しました`);
+        window.requestAnimationFrame(() => {
+          document.getElementById(`${formId}-amount`)?.focus();
+        });
+        return;
       }
 
+      toast.success(source.kind === 'edit' ? '取引を更新しました' : '取引を登録しました', {
+        description: `${getTypeLabel(transaction.type)}: ¥${transaction.amount.toLocaleString()}`,
+      });
       onOpenChange(false);
     } catch (error) {
       console.error('取引処理エラー:', error);
-      const action = isEditMode ? '更新' : '登録';
-      toast.error(error instanceof Error ? error.message : `取引の${action}に失敗しました`);
+      // ストアの error をページ側で一度だけ表示する。
     }
   };
 
-  /**
-   * タブ変更時の処理
-   */
   const handleTabChange = (value: string) => {
-    const newType = value as TransactionType;
-    setValue('type', newType);
-
-    if ((newType === 'expense' || newType === 'advance') && !watch('payerUserId')) {
+    const nextType = value as TransactionType;
+    setValue('type', nextType);
+    if ((nextType === 'expense' || nextType === 'advance') && !watch('payerUserId')) {
       setValue('payerUserId', currentUser?.id ?? null);
     }
-
-    if (newType === 'income') {
+    if (nextType === 'income') {
       setValue('payerUserId', null);
       setValue('advanceToUserId', null);
     }
-
-    const nextCategories = getCategoriesByType(newType);
-    if (nextCategories[0]) {
-      setValue('category', nextCategories[0].key);
-    }
+    const nextCategory = getCategoriesByType(nextType)[0];
+    if (nextCategory) setValue('category', nextCategory.key);
+    setSavedMessage(null);
   };
+
+  const id = (field: string) => `${formId}-${field}`;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl">
-        <DialogHeader>
+      <DialogContent className="bottom-0 left-0 top-auto max-h-[100dvh] w-full max-w-none translate-x-0 translate-y-0 rounded-b-none rounded-t-2xl p-0 data-[state=open]:zoom-in-100 sm:bottom-auto sm:left-[50%] sm:top-[50%] sm:max-h-[calc(100dvh-2rem)] sm:max-w-xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg">
+        <DialogHeader className="sticky top-0 z-10 border-b bg-white px-5 py-4 pr-12 text-left">
           <DialogTitle>{isEditMode ? '取引を編集' : '取引を登録'}</DialogTitle>
           <DialogDescription>
-            {isEditMode
-              ? '取引内容を編集して更新しましょう'
-              : '支出・収入・立替を記録して家計を把握しましょう'}
+            {isEditMode ? '取引内容を編集します' : '支出・収入・立替を記録します'}
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs value={transactionType} onValueChange={handleTabChange}>
-          <TabsList className="w-full">
-            <TabsTrigger value="expense" disabled={isEditMode}>支出</TabsTrigger>
-            <TabsTrigger value="income" disabled={isEditMode}>収入</TabsTrigger>
-            <TabsTrigger value="advance" disabled={isEditMode}>立替</TabsTrigger>
-          </TabsList>
+        <Tabs value={transactionType} onValueChange={handleTabChange} className="gap-0">
+          <div className="px-5 pt-4">
+            <TabsList className="min-h-11 w-full">
+              <TabsTrigger className="min-h-11 touch-manipulation" value="expense" disabled={locksType}>支出</TabsTrigger>
+              <TabsTrigger className="min-h-11 touch-manipulation" value="income" disabled={locksType}>収入</TabsTrigger>
+              <TabsTrigger className="min-h-11 touch-manipulation" value="advance" disabled={locksType}>立替</TabsTrigger>
+            </TabsList>
+          </div>
 
-          <form
-            onSubmit={handleSubmit(onSubmit)}
-            className="mt-4 space-y-5"
-          >
-            <TabsContent value={transactionType}>
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="amount">金額</Label>
-                  <div className="flex gap-2">
-                    <Input
-                      id="amount"
-                      type="number"
-                      min={1}
-                      step="1"
-                      placeholder="金額を入力"
-                      disabled={isSubmitting}
-                      className="flex-1"
-                      {...register('amount', { valueAsNumber: true })}
-                    />
-                    <AmountCalculatorPopover
-                      disabled={isSubmitting}
-                      onApply={(total) => setValue('amount', total, { shouldValidate: true })}
-                    />
-                  </div>
-                  {errors.amount && (
-                    <p className="text-sm text-red-500">{errors.amount.message}</p>
-                  )}
-                </div>
+          <form className="space-y-5 px-5 pb-0 pt-4" onSubmit={(event) => event.preventDefault()}>
+            {savedMessage && (
+              <div role="status" className="flex items-center gap-2 rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+                <CheckCircle2 className="h-4 w-4" />{savedMessage}
+              </div>
+            )}
 
-                <div className="space-y-2">
-                  <Label htmlFor="occurredOn">日付</Label>
-                  <Input
-                    id="occurredOn"
-                    type="date"
-                    disabled={isSubmitting}
-                    {...register('occurredOn')}
-                  />
-                  {errors.occurredOn && (
-                    <p className="text-sm text-red-500">{errors.occurredOn.message}</p>
-                  )}
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor={id('amount')}>金額</Label>
+                <div className="flex gap-2">
+                  <CurrencyInput id={id('amount')} placeholder="金額を入力" disabled={isSubmitting} className="flex-1" aria-invalid={!!errors.amount} {...register('amount')} />
+                  <AmountCalculatorPopover disabled={isSubmitting} onApply={(total) => setValue('amount', total, { shouldValidate: true })} />
                 </div>
+                {errors.amount && <p className="text-sm text-red-500">{errors.amount.message}</p>}
               </div>
 
               <div className="space-y-2">
-              <Label htmlFor="category">カテゴリ</Label>
-              <select
-                id="category"
-                className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed"
-                disabled={isSubmitting}
-                {...register('category')}
-              >
-                {categoriesForType.map((item) => (
-                  <option key={item.key} value={item.key}>
-                    {item.label}
-                  </option>
-                ))}
+                <Label htmlFor={id('occurredOn')}>日付</Label>
+                <Input id={id('occurredOn')} type="date" className="min-h-11 text-base touch-manipulation" disabled={isSubmitting} {...register('occurredOn')} />
+                {errors.occurredOn && <p className="text-sm text-red-500">{errors.occurredOn.message}</p>}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={id('category')}>カテゴリ</Label>
+              <select id={id('category')} className="min-h-11 w-full touch-manipulation rounded-md border border-gray-200 bg-white px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" disabled={isSubmitting} {...register('category')}>
+                {categoriesForType.map((item) => <option key={item.key} value={item.key}>{item.label}</option>)}
               </select>
-              {errors.category && (
-                <p className="text-sm text-red-500">{errors.category.message}</p>
-                )}
-              </div>
+              {errors.category && <p className="text-sm text-red-500">{errors.category.message}</p>}
+            </div>
 
-              {transactionType === 'expense' && (
-                <div className="rounded-lg border border-dashed border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-                  <label className="flex items-start gap-3">
-                    <Controller
-                      name="isHouseholdAdvance"
-                      control={control}
-                      render={({ field }) => (
-                        <input
-                          type="checkbox"
-                          className="mt-1 h-4 w-4 rounded border border-amber-300 accent-amber-500"
-                          checked={field.value ?? false}
-                          onChange={(event) => field.onChange(event.target.checked)}
-                          disabled={isSubmitting}
-                        />
-                      )}
-                    />
-                    <span>
-                      家庭の支出を一旦立替えた場合はチェックしてください。<br />
-                      後で精算できるよう立替として計上します。
-                    </span>
-                  </label>
-                </div>
-              )}
+            {transactionType === 'expense' && (
+              <label className="flex min-h-11 touch-manipulation items-start gap-3 rounded-lg border border-dashed border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                <Controller name="isHouseholdAdvance" control={control} render={({ field }) => (
+                  <input type="checkbox" className="mt-0.5 h-5 w-5 shrink-0 accent-amber-500" checked={field.value ?? false} onChange={(event) => field.onChange(event.target.checked)} disabled={isSubmitting} />
+                )} />
+                <span>家庭の支出を一旦立替えた場合はチェックしてください。後で世帯との精算に表示されます。</span>
+              </label>
+            )}
 
+            <div className="space-y-2">
+              <Label htmlFor={id('note')}>メモ</Label>
+              <textarea id={id('note')} rows={3} className="min-h-20 w-full touch-manipulation rounded-md border border-gray-200 px-3 py-2 text-base focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" placeholder="どんな取引かメモできます" disabled={isSubmitting} {...register('note')} />
+              {errors.note && <p className="text-sm text-red-500">{errors.note.message}</p>}
+            </div>
+
+            {transactionType !== 'income' && (
               <div className="space-y-2">
-                <Label htmlFor="note">メモ</Label>
-                <textarea
-                  id="note"
-                  rows={3}
-                  className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed"
-                  placeholder="どんな取引かメモできます"
-                  disabled={isSubmitting}
-                  {...register('note')}
-                />
-                {errors.note && (
-                  <p className="text-sm text-red-500">{errors.note.message}</p>
-                )}
+                <Label htmlFor={id('place')}>場所（任意）</Label>
+                <Controller name="place" control={control} render={({ field }) => (
+                  <PlaceCombobox id={id('place')} value={field.value ?? ''} onChange={field.onChange} suggestions={placeSuggestions} disabled={isSubmitting} />
+                )} />
+                {errors.place && <p className="text-sm text-red-500">{errors.place.message}</p>}
               </div>
+            )}
 
-              {transactionType !== 'income' && (
-                <div className="space-y-2">
-                  <Label htmlFor="place">場所（任意）</Label>
-                  <Input
-                    id="place"
-                    type="text"
-                    list="place-suggestions"
-                    placeholder="例：スーパー、コンビニ"
-                    disabled={isSubmitting}
-                    {...register('place')}
-                  />
-                  <datalist id="place-suggestions">
-                    {placeSuggestions.map((p) => (
-                      <option key={p} value={p} />
-                    ))}
-                  </datalist>
-                  {errors.place && (
-                    <p className="text-sm text-red-500">{errors.place.message}</p>
-                  )}
-                </div>
+            {(transactionType === 'expense' || transactionType === 'advance') && (
+              <div className="space-y-2">
+                <Label htmlFor={id('payer')}>支払者</Label>
+                <Controller name="payerUserId" control={control} render={({ field }) => (
+                  <select id={id('payer')} className="min-h-11 w-full touch-manipulation rounded-md border border-gray-200 bg-white px-3 py-2 text-base" disabled={isSubmitting} value={field.value ?? ''} onChange={(event) => field.onChange(event.target.value || null)}>
+                    <option value="" disabled>支払者を選択</option>
+                    {members.map((member) => <option key={member.userId} value={member.userId}>{getMemberLabel(member)}{member.userId === currentUser?.id ? '（自分）' : ''}</option>)}
+                  </select>
+                )} />
+                {errors.payerUserId && <p className="text-sm text-red-500">{errors.payerUserId.message}</p>}
+              </div>
+            )}
+
+            {transactionType === 'advance' && (
+              <div className="space-y-2">
+                <Label htmlFor={id('advanceTo')}>立替先</Label>
+                <Controller name="advanceToUserId" control={control} render={({ field }) => (
+                  <select id={id('advanceTo')} className="min-h-11 w-full touch-manipulation rounded-md border border-gray-200 bg-white px-3 py-2 text-base" disabled={isSubmitting} value={field.value ?? '__household__'} onChange={(event) => field.onChange(event.target.value === '__household__' ? null : event.target.value)}>
+                    <option value="__household__">家庭全体に立替</option>
+                    {members.filter((member) => member.userId !== payerUserId).map((member) => <option key={member.userId} value={member.userId}>{getMemberLabel(member)}{member.userId === currentUser?.id ? '（自分）' : ''}</option>)}
+                  </select>
+                )} />
+              </div>
+            )}
+
+            <div className="sticky bottom-0 -mx-5 flex gap-2 border-t bg-white px-5 py-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+              <Button type="button" variant="outline" className="min-h-11 flex-1 touch-manipulation" onClick={() => onOpenChange(false)} disabled={isSubmitting}>キャンセル</Button>
+              {source.kind === 'create' && (
+                <Button type="button" variant="outline" className="min-h-11 flex-1 touch-manipulation" disabled={isSubmitting} onClick={handleSubmit(save('continue'))}>{isSubmitting ? '保存中...' : '登録して続ける'}</Button>
               )}
-
-              {(transactionType === 'expense' || transactionType === 'advance') && (
-                <div className="space-y-2">
-                  <Label>支払者</Label>
-                  <Controller
-                    name="payerUserId"
-                    control={control}
-                    render={({ field }) => (
-                      <select
-                        className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed"
-                        disabled={isSubmitting}
-                        value={field.value ?? ''}
-                        onChange={(event) =>
-                          field.onChange(event.target.value ? event.target.value : null)
-                        }
-                      >
-                        <option value="" disabled>
-                          支払者を選択
-                        </option>
-                        {members.map((member) => (
-                          <option key={member.userId} value={member.userId}>
-                            {getMemberLabel(member)}
-                            {member.userId === currentUser?.id ? '（自分）' : ''}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                  />
-                  {errors.payerUserId && (
-                    <p className="text-sm text-red-500">{errors.payerUserId.message}</p>
-                  )}
-                </div>
-              )}
-
-              {transactionType === 'advance' && (
-                <div className="space-y-2">
-                  <Label>立替先</Label>
-                  <Controller
-                    name="advanceToUserId"
-                    control={control}
-                    render={({ field }) => (
-                      <select
-                        className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed"
-                        disabled={isSubmitting}
-                        value={field.value ?? '__household__'}
-                        onChange={(event) =>
-                          field.onChange(
-                            event.target.value === '__household__'
-                              ? null
-                              : event.target.value
-                          )
-                        }
-                      >
-                        <option value="__household__">家庭全体に立替</option>
-                        {members
-                          .filter((member) => member.userId !== payerUserId)
-                          .map((member) => (
-                            <option key={member.userId} value={member.userId}>
-                              {getMemberLabel(member)}
-                              {member.userId === currentUser?.id ? '（自分）' : ''}
-                            </option>
-                          ))}
-                      </select>
-                    )}
-                  />
-                  {errors.advanceToUserId && (
-                    <p className="text-sm text-red-500">{errors.advanceToUserId.message}</p>
-                  )}
-                  <p className="text-xs text-gray-500">
-                    家庭全体を選ぶと household 全体への立替として計上します
-                  </p>
-                </div>
-              )}
-            </TabsContent>
-
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isSubmitting}
-                className="flex-1"
-              >
-                キャンセル
-              </Button>
-              <Button type="submit" disabled={isSubmitting} className="flex-1">
-                {isSubmitting ? '保存中...' : isEditMode ? '更新する' : '登録する'}
-              </Button>
+              <Button type="button" className="min-h-11 flex-1 touch-manipulation" disabled={isSubmitting} onClick={handleSubmit(save('close'))}>{isSubmitting ? '保存中...' : isEditMode ? '更新する' : '登録して閉じる'}</Button>
             </div>
           </form>
         </Tabs>
       </DialogContent>
     </Dialog>
   );
-}
-
-/**
- * 取引タイプの表示名
- */
-function getTypeLabel(type: TransactionType): string {
-  switch (type) {
-    case 'income':
-      return '収入';
-    case 'advance':
-      return '立替';
-    case 'expense':
-    default:
-      return '支出';
-  }
 }

--- a/apps/web/src/components/transactions/AmountCalculatorPopover.tsx
+++ b/apps/web/src/components/transactions/AmountCalculatorPopover.tsx
@@ -47,7 +47,7 @@ export function AmountCalculatorPopover({ onApply, disabled }: AmountCalculatorP
           type="button"
           aria-label="かんたん電卓を開く"
           disabled={disabled}
-          className="flex w-12 shrink-0 items-center justify-center rounded-[13px] bg-pb-primary-soft text-[var(--pb-primary-hover)] shadow-[inset_0_0_0_1.5px_var(--pb-border)] disabled:opacity-50"
+          className="flex min-h-11 w-12 shrink-0 touch-manipulation items-center justify-center rounded-[13px] bg-pb-primary-soft text-[var(--pb-primary-hover)] shadow-[inset_0_0_0_1.5px_var(--pb-border)] disabled:opacity-50"
         >
           <CalculatorIcon className="size-5" />
         </button>
@@ -63,7 +63,7 @@ export function AmountCalculatorPopover({ onApply, disabled }: AmountCalculatorP
               key={key}
               type="button"
               onClick={() => setState((s) => inputDigit(s, key))}
-              className="rounded-[10px] bg-pb-bg py-2 text-base font-bold"
+              className="min-h-11 touch-manipulation rounded-[10px] bg-pb-bg py-2 text-base font-bold"
             >
               {key}
             </button>
@@ -72,14 +72,14 @@ export function AmountCalculatorPopover({ onApply, disabled }: AmountCalculatorP
             type="button"
             aria-label="足す"
             onClick={() => setState((s) => pressPlus(s))}
-            className="rounded-[10px] bg-pb-primary-soft py-2 text-base font-bold text-[var(--pb-primary-hover)]"
+            className="min-h-11 touch-manipulation rounded-[10px] bg-pb-primary-soft py-2 text-base font-bold text-[var(--pb-primary-hover)]"
           >
             ＋
           </button>
           <button
             type="button"
             onClick={() => setState((s) => inputDigit(s, '0'))}
-            className="rounded-[10px] bg-pb-bg py-2 text-base font-bold"
+            className="min-h-11 touch-manipulation rounded-[10px] bg-pb-bg py-2 text-base font-bold"
           >
             0
           </button>
@@ -87,7 +87,7 @@ export function AmountCalculatorPopover({ onApply, disabled }: AmountCalculatorP
             type="button"
             aria-label="1文字削除"
             onClick={() => setState((s) => backspace(s))}
-            className="flex items-center justify-center rounded-[10px] bg-pb-expense-soft py-2 text-pb-expense"
+            className="flex min-h-11 touch-manipulation items-center justify-center rounded-[10px] bg-pb-expense-soft py-2 text-pb-expense"
           >
             <Delete className="size-4" />
           </button>

--- a/apps/web/src/components/transactions/CurrencyInput.test.tsx
+++ b/apps/web/src/components/transactions/CurrencyInput.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CurrencyInput } from './CurrencyInput';
+
+describe('CurrencyInput', () => {
+  it('iPhone向けの数字キーボードと44pxの操作領域を使う', () => {
+    render(<CurrencyInput aria-label="金額" />);
+    const input = screen.getByRole('textbox', { name: '金額' });
+    expect(input).toHaveAttribute('inputmode', 'numeric');
+    expect(input).toHaveClass('min-h-11');
+  });
+});

--- a/apps/web/src/components/transactions/CurrencyInput.tsx
+++ b/apps/web/src/components/transactions/CurrencyInput.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import * as React from 'react';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+/** iPhoneでも安定して数字キーボードを開く円金額入力。 */
+export const CurrencyInput = React.forwardRef<
+  HTMLInputElement,
+  Omit<React.ComponentProps<typeof Input>, 'type' | 'inputMode'>
+>(({ className, ...props }, ref) => (
+  <Input
+    ref={ref}
+    type="text"
+    inputMode="numeric"
+    pattern="[0-9,]*"
+    autoComplete="off"
+    className={cn('min-h-11 text-base touch-manipulation', className)}
+    {...props}
+  />
+));
+
+CurrencyInput.displayName = 'CurrencyInput';

--- a/apps/web/src/components/transactions/PlaceCombobox.test.tsx
+++ b/apps/web/src/components/transactions/PlaceCombobox.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PlaceCombobox } from './PlaceCombobox';
+
+const suggestions = [
+  { place: 'スーパー田中', useCount: 4, lastUsedOn: '2026-07-20' },
+  { place: 'ドラッグてらだ', useCount: 2, lastUsedOn: '2026-07-18' },
+  { place: 'スーパーマルイ', useCount: 1, lastUsedOn: '2026-07-10' },
+];
+
+describe('PlaceCombobox', () => {
+  it('フォーカス時に複数候補を表示し、入力内容で部分一致する', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <PlaceCombobox id="place" value="" onChange={onChange} suggestions={suggestions} />
+    );
+
+    fireEvent.focus(screen.getByRole('combobox'));
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+
+    rerender(
+      <PlaceCombobox id="place" value="スーパー" onChange={onChange} suggestions={suggestions} />
+    );
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  it('矢印キーとEnterで候補を選べる', () => {
+    const onChange = vi.fn();
+    render(<PlaceCombobox id="place" value="" onChange={onChange} suggestions={suggestions} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenCalledWith('スーパー田中');
+  });
+});

--- a/apps/web/src/components/transactions/PlaceCombobox.tsx
+++ b/apps/web/src/components/transactions/PlaceCombobox.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useId, useMemo, useState } from 'react';
+import { MapPin } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import type { PlaceSuggestion } from '@/types/transaction';
+
+interface PlaceComboboxProps {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  suggestions: PlaceSuggestion[];
+  disabled?: boolean;
+}
+
+const MAX_VISIBLE_SUGGESTIONS = 8;
+
+export function PlaceCombobox({
+  id,
+  value,
+  onChange,
+  suggestions,
+  disabled,
+}: PlaceComboboxProps) {
+  const generatedId = useId();
+  const listboxId = `${generatedId}-listbox`;
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const filteredSuggestions = useMemo(() => {
+    const query = value.trim().toLocaleLowerCase('ja');
+    const filtered = query
+      ? suggestions.filter((item) => item.place.toLocaleLowerCase('ja').includes(query))
+      : suggestions;
+    return filtered.slice(0, MAX_VISIBLE_SUGGESTIONS);
+  }, [suggestions, value]);
+
+  const choose = (place: string) => {
+    onChange(place);
+    setIsOpen(false);
+    setActiveIndex(-1);
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        id={id}
+        value={value}
+        type="text"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={isOpen && filteredSuggestions.length > 0}
+        aria-controls={listboxId}
+        aria-activedescendant={activeIndex >= 0 ? `${listboxId}-${activeIndex}` : undefined}
+        autoComplete="off"
+        placeholder="例：スーパー、コンビニ"
+        disabled={disabled}
+        className="min-h-11 text-base touch-manipulation"
+        onFocus={() => setIsOpen(true)}
+        onBlur={() => {
+          setIsOpen(false);
+          setActiveIndex(-1);
+        }}
+        onChange={(event) => {
+          onChange(event.target.value);
+          setIsOpen(true);
+          setActiveIndex(-1);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown' && filteredSuggestions.length > 0) {
+            event.preventDefault();
+            setIsOpen(true);
+            setActiveIndex((current) => Math.min(current + 1, filteredSuggestions.length - 1));
+          } else if (event.key === 'ArrowUp' && filteredSuggestions.length > 0) {
+            event.preventDefault();
+            setActiveIndex((current) => Math.max(current - 1, 0));
+          } else if (event.key === 'Enter' && activeIndex >= 0) {
+            event.preventDefault();
+            choose(filteredSuggestions[activeIndex].place);
+          } else if (event.key === 'Escape') {
+            setIsOpen(false);
+            setActiveIndex(-1);
+          }
+        }}
+      />
+
+      {isOpen && filteredSuggestions.length > 0 && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute z-[70] mt-1 max-h-64 w-full overflow-y-auto rounded-md border bg-white p-1 shadow-lg"
+        >
+          {filteredSuggestions.map((suggestion, index) => (
+            <li
+              id={`${listboxId}-${index}`}
+              key={suggestion.place}
+              role="option"
+              aria-selected={index === activeIndex}
+            >
+              <button
+                type="button"
+                className="flex min-h-11 w-full touch-manipulation items-center justify-between gap-3 rounded px-3 py-2 text-left text-sm hover:bg-blue-50 focus:bg-blue-50 focus:outline-none aria-selected:bg-blue-50"
+                onPointerDown={(event) => {
+                  event.preventDefault();
+                  choose(suggestion.place);
+                }}
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <MapPin className="h-4 w-4 shrink-0 text-gray-400" />
+                  <span className="truncate">{suggestion.place}</span>
+                </span>
+                <span className="shrink-0 text-xs text-gray-400">{suggestion.useCount}回</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-2 right-2 flex size-11 touch-manipulation items-center justify-center rounded-md opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-5"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/apps/web/src/lib/__tests__/dashboard.test.ts
+++ b/apps/web/src/lib/__tests__/dashboard.test.ts
@@ -21,6 +21,8 @@ function makeTx(overrides: Partial<Transaction> = {}): Transaction {
     payerUserId: null,
     advanceToUserId: null,
     place: null,
+    recurringExpenseId: null,
+    recurringIncomeId: null,
     createdBy: 'user-1',
     createdAt: '2026-05-15T00:00:00Z',
     updatedAt: '2026-05-15T00:00:00Z',

--- a/apps/web/src/lib/validations/__tests__/transaction.test.ts
+++ b/apps/web/src/lib/validations/__tests__/transaction.test.ts
@@ -7,7 +7,7 @@ const base = {
   occurredOn: '2026-06-03',
   category: 'groceries',
   isHouseholdAdvance: false,
-  payerUserId: '00000000-0000-0000-0000-000000000001',
+  payerUserId: '11111111-1111-4111-8111-111111111111',
   advanceToUserId: null,
 };
 

--- a/apps/web/src/lib/validations/settlement.ts
+++ b/apps/web/src/lib/validations/settlement.ts
@@ -6,12 +6,6 @@ import { z } from 'zod';
 
 export const HOUSEHOLD_SETTLEMENT_KEY = '__household__';
 
-const settlementDirectionEnum = z.enum(['pay', 'receive']);
-const partnerSelectionSchema = z.union([
-  z.literal(HOUSEHOLD_SETTLEMENT_KEY),
-  z.string().uuid('相手を選択してください'),
-]);
-
 /**
  * YYYY-MM-DD 形式の妥当性確認
  */
@@ -42,10 +36,8 @@ function isValidDate(value: string): boolean {
  * 精算フォームのスキーマ
  */
 export const settlementSchema = z.object({
-  /** 精算方向 */
-  direction: settlementDirectionEnum,
-  /** 相手ユーザーID */
-  partnerUserId: partnerSelectionSchema,
+  /** 精算対象となる残高明細のキー */
+  targetKey: z.string().min(1, '精算する残高を選択してください'),
   /** 金額 */
   amount: z
     .preprocess((value) => {

--- a/apps/web/src/services/__tests__/settlements.test.ts
+++ b/apps/web/src/services/__tests__/settlements.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { groupBalanceBreakdowns } from '@/services/settlements';
+
+describe('groupBalanceBreakdowns', () => {
+  it('世帯向け残高と家族間残高を混ぜず、合計だけを集約する', () => {
+    const result = groupBalanceBreakdowns([
+      {
+        subject_user_id: 'user-a',
+        subject_user_name: '太郎',
+        counterparty_user_id: null,
+        counterparty_user_name: null,
+        balance_amount: 90000,
+        is_over_settled: false,
+      },
+      {
+        subject_user_id: 'user-a',
+        subject_user_name: '太郎',
+        counterparty_user_id: 'user-b',
+        counterparty_user_name: '花子',
+        balance_amount: 4000,
+        is_over_settled: false,
+      },
+      {
+        subject_user_id: 'user-b',
+        subject_user_name: '花子',
+        counterparty_user_id: 'user-a',
+        counterparty_user_name: '太郎',
+        balance_amount: -4000,
+        is_over_settled: false,
+      },
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].balanceAmount).toBe(94000);
+    expect(result[0].breakdowns).toEqual([
+      expect.objectContaining({ counterpartyUserId: null, balanceAmount: 90000 }),
+      expect.objectContaining({ counterpartyUserId: 'user-b', balanceAmount: 4000 }),
+    ]);
+    expect(result[1].balanceAmount).toBe(-4000);
+  });
+});

--- a/apps/web/src/services/recurringExpenses.ts
+++ b/apps/web/src/services/recurringExpenses.ts
@@ -5,6 +5,7 @@
  */
 
 import { createClient } from '@/lib/supabase/client';
+import { formatLocalDate } from '@/lib/utils';
 import type {
   RecurringExpense,
   RecurringExpenseData,
@@ -207,7 +208,7 @@ export async function generateFixedTransactionsByDate(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (supabase.rpc as any)('generate_fixed_transactions_by_date', {
     target_household: householdId,
-    target_date: targetDate || new Date().toISOString().split('T')[0],
+    target_date: targetDate || formatLocalDate(),
   });
 
   if (error) {
@@ -237,7 +238,7 @@ export async function getVariableExpenseReminders(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data, error } = await (supabase.rpc as any)('get_variable_expense_reminders', {
     target_household: householdId,
-    target_date: targetDate || new Date().toISOString().split('T')[0],
+    target_date: targetDate || formatLocalDate(),
   });
 
   if (error) {
@@ -253,4 +254,26 @@ export async function getVariableExpenseReminders(
     note: item.note as string | null,
     payerUserId: item.payer_user_id as string,
   }));
+}
+
+/** 今月分の変動費リマインダーを非表示にする。 */
+export async function dismissVariableExpenseReminder(
+  recurringExpenseId: string,
+  targetDate = formatLocalDate()
+): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('認証が必要です');
+
+  const periodMonth = `${targetDate.slice(0, 7)}-01`;
+  const { error } = await supabase.from('recurring_reminder_dismissals').insert({
+    recurring_expense_id: recurringExpenseId,
+    recurring_income_id: null,
+    period_month: periodMonth,
+    dismissed_by: user.id,
+  });
+
+  if (error && error.code !== '23505') {
+    console.error('変動費リマインダー非表示エラー:', error);
+    throw new Error('リマインダーを非表示にできませんでした');
+  }
 }

--- a/apps/web/src/services/recurringIncomes.ts
+++ b/apps/web/src/services/recurringIncomes.ts
@@ -165,6 +165,28 @@ export async function getIncomeReminders(
   }));
 }
 
+/** 今月分の収入リマインダーを非表示にする。 */
+export async function dismissRecurringIncomeReminder(
+  recurringIncomeId: string,
+  targetDate = formatLocalDate()
+): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('認証が必要です');
+
+  const periodMonth = `${targetDate.slice(0, 7)}-01`;
+  const { error } = await supabase.from('recurring_reminder_dismissals').insert({
+    recurring_expense_id: null,
+    recurring_income_id: recurringIncomeId,
+    period_month: periodMonth,
+    dismissed_by: user.id,
+  });
+
+  if (error && error.code !== '23505') {
+    console.error('収入リマインダー非表示エラー:', error);
+    throw new Error('リマインダーを非表示にできませんでした');
+  }
+}
+
 /**
  * データベースの定期収入データをアプリケーションの型に変換
  *

--- a/apps/web/src/services/settlements.ts
+++ b/apps/web/src/services/settlements.ts
@@ -6,10 +6,16 @@
 
 import { createClient } from '@/lib/supabase/client';
 import type { Database } from '@/types/supabase';
-import type { HouseholdBalance, Settlement, SettlementData } from '@/types/settlement';
+import type {
+  BalanceSettlementData,
+  HouseholdBalance,
+  HouseholdBalanceBreakdown,
+  Settlement,
+  SettlementData,
+} from '@/types/settlement';
 
-type BalanceRow =
-  Database['public']['Functions']['get_household_balances']['Returns'][number];
+type BalanceBreakdownRow =
+  Database['public']['Functions']['get_household_balance_breakdown']['Returns'][number];
 type SettlementRow = Database['public']['Tables']['settlements']['Row'];
 type SettlementInsert = Database['public']['Tables']['settlements']['Insert'];
 
@@ -53,33 +59,75 @@ export async function getHouseholdBalances(
 ): Promise<HouseholdBalance[]> {
   const supabase = createClient();
 
-  const rpcArgs = {
+  const { data, error } = await supabase.rpc('get_household_balance_breakdown', {
     target_household: householdId,
-  };
-
-  // RPC関数を呼び出し (@supabase/ssr型定義の問題により型アサーション使用)
-  // TODO: Supabase CLIで型定義を自動生成し、as anyを削除する (チケット: PB-66)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (supabase as any).rpc(
-    'get_household_balances',
-    rpcArgs
-  );
+  });
 
   if (error) {
     console.error('立替残高取得エラー:', error);
     throw new Error('立替残高の取得に失敗しました');
   }
 
-  const rows: BalanceRow[] = data ?? [];
+  return groupBalanceBreakdowns((data ?? []) as BalanceBreakdownRow[]);
+}
 
-  return rows.map((item) => ({
-    userId: item.user_id,
-    userName: item.user_name,
-    balanceAmount:
-      typeof item.balance_amount === 'string'
-        ? Number(item.balance_amount)
-        : item.balance_amount,
-  }));
+/** RPCの明細行をメンバー単位にまとめる純粋変換。 */
+export function groupBalanceBreakdowns(rows: BalanceBreakdownRow[]): HouseholdBalance[] {
+  const byUser = new Map<string, HouseholdBalance>();
+
+  rows.forEach((item) => {
+    const detail: HouseholdBalanceBreakdown = {
+      subjectUserId: item.subject_user_id,
+      subjectUserName: item.subject_user_name,
+      counterpartyUserId: item.counterparty_user_id,
+      counterpartyUserName: item.counterparty_user_name,
+      balanceAmount: Number(item.balance_amount),
+      isOverSettled: item.is_over_settled,
+    };
+    const current = byUser.get(detail.subjectUserId) ?? {
+      userId: detail.subjectUserId,
+      userName: detail.subjectUserName,
+      balanceAmount: 0,
+      breakdowns: [],
+    };
+    current.balanceAmount += detail.balanceAmount;
+    current.breakdowns.push(detail);
+    byUser.set(detail.subjectUserId, current);
+  });
+
+  return Array.from(byUser.values());
+}
+
+/** 残高明細に対する精算を、DB側の残高検証付きで作成する。 */
+export async function createBalanceSettlement(
+  input: BalanceSettlementData
+): Promise<Settlement> {
+  const supabase = createClient();
+  const { data, error } = await supabase.rpc('create_balance_settlement', {
+    target_household: input.householdId,
+    target_subject_user: input.subjectUserId,
+    target_counterparty_user: input.counterpartyUserId,
+    target_amount: input.amount,
+    target_settled_on: input.settledOn,
+    target_note: input.note?.trim() ? input.note.trim() : null,
+  });
+
+  if (error) {
+    console.error('残高精算作成エラー:', error);
+    if (error.message.includes('exceeds the outstanding balance')) {
+      throw new Error('精算額が現在の立替残高を超えています');
+    }
+    if (error.message.includes('no outstanding balance')) {
+      throw new Error('精算できる立替残高がありません');
+    }
+    throw new Error('精算の記録に失敗しました');
+  }
+
+  const row = data?.[0];
+  if (!row) {
+    throw new Error('精算結果を取得できませんでした');
+  }
+  return mapSettlement(row);
 }
 
 /**
@@ -169,10 +217,18 @@ export async function createSettlement(input: SettlementData): Promise<Settlemen
 export async function deleteSettlement(id: string): Promise<void> {
   const supabase = createClient();
 
-  const { error } = await supabase.from('settlements').delete().eq('id', id);
+  const { data, error } = await supabase
+    .from('settlements')
+    .delete()
+    .eq('id', id)
+    .select('id');
 
   if (error) {
     console.error('精算削除エラー:', error);
     throw new Error('精算の削除に失敗しました');
+  }
+
+  if (!data || data.length === 0) {
+    throw new Error('精算を削除できませんでした（対象が見つからないか、権限がありません）');
   }
 }

--- a/apps/web/src/services/transactions.ts
+++ b/apps/web/src/services/transactions.ts
@@ -12,6 +12,7 @@ import {
   type Transaction,
   type TransactionCategoryKey,
   type TransactionData,
+  type PlaceSuggestion,
 } from '@/types/transaction';
 
 type TransactionRow = Database['public']['Tables']['transactions']['Row'];
@@ -27,6 +28,8 @@ const TRANSACTION_SELECT = `
   place,
   payer_user_id,
   advance_to_user_id,
+  recurring_expense_id,
+  recurring_income_id,
   created_by,
   created_at,
   updated_at
@@ -52,6 +55,8 @@ function mapTransaction(row: TransactionRow): Transaction {
     place: row.place,
     payerUserId: row.payer_user_id,
     advanceToUserId: row.advance_to_user_id,
+    recurringExpenseId: row.recurring_expense_id,
+    recurringIncomeId: row.recurring_income_id,
     createdBy: row.created_by,
     createdAt: row.created_at || new Date().toISOString(),
     updatedAt: row.updated_at || new Date().toISOString(),
@@ -228,6 +233,8 @@ export async function createTransaction(input: TransactionData): Promise<Transac
     place: input.place?.trim() ? input.place.trim() : null,
     payer_user_id: input.payerUserId ?? null,
     advance_to_user_id: input.type === 'advance' ? input.advanceToUserId ?? null : null,
+    recurring_expense_id: input.recurringExpenseId ?? null,
+    recurring_income_id: input.recurringIncomeId ?? null,
     created_by: session.user.id,
   };
 
@@ -333,6 +340,12 @@ export async function updateTransaction(
   if (input.advanceToUserId !== undefined && input.type === 'advance') {
     payload.advance_to_user_id = input.advanceToUserId ?? null;
   }
+  if (input.recurringExpenseId !== undefined) {
+    payload.recurring_expense_id = input.recurringExpenseId ?? null;
+  }
+  if (input.recurringIncomeId !== undefined) {
+    payload.recurring_income_id = input.recurringIncomeId ?? null;
+  }
 
   // @supabase/ssr型定義の問題により型アサーション使用
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -355,12 +368,10 @@ export async function updateTransaction(
  * 世帯内の過去の場所（place）をサジェスト用に取得する。
  * @returns 重複なし・昇順の場所リスト。失敗時は空配列。
  */
-export async function getPlaceSuggestions(householdId: string): Promise<string[]> {
+export async function getPlaceSuggestions(householdId: string): Promise<PlaceSuggestion[]> {
   const supabase = createClient();
 
-  // rpc は既存の insert/update と同様に型アサーションで通す（Functions 型未生成のため）
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (supabase as any).rpc('get_place_suggestions', {
+  const { data, error } = await supabase.rpc('get_ranked_place_suggestions', {
     target_household: householdId,
   });
 
@@ -369,7 +380,9 @@ export async function getPlaceSuggestions(householdId: string): Promise<string[]
     return [];
   }
 
-  return ((data ?? []) as { place: string | null }[])
-    .map((row) => row.place)
-    .filter((place): place is string => Boolean(place));
+  return (data ?? []).map((row) => ({
+    place: row.place,
+    useCount: Number(row.use_count),
+    lastUsedOn: row.last_used_on,
+  }));
 }

--- a/apps/web/src/store/__tests__/useRecurringExpenseStore.test.ts
+++ b/apps/web/src/store/__tests__/useRecurringExpenseStore.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dismissVariableExpenseReminder } from '@/services/recurringExpenses';
+import { useRecurringExpenseStore } from '@/store/useRecurringExpenseStore';
+import type { RecurringExpense, VariableExpenseReminder } from '@/types/transaction';
+
+vi.mock('@/services/recurringExpenses', () => ({
+  listRecurringExpenses: vi.fn(),
+  createRecurringExpense: vi.fn(),
+  updateRecurringExpense: vi.fn(),
+  deleteRecurringExpense: vi.fn().mockResolvedValue(undefined),
+  generateMissingTransactions: vi.fn(),
+  generateFixedTransactionsByDate: vi.fn(),
+  getVariableExpenseReminders: vi.fn(),
+  dismissVariableExpenseReminder: vi.fn().mockResolvedValue(undefined),
+}));
+
+function makeExpense(id: string): RecurringExpense {
+  return {
+    id,
+    householdId: 'hh-1',
+    amount: 12000,
+    dayOfMonth: 20,
+    category: 'other',
+    note: null,
+    payerUserId: 'user-1',
+    isActive: true,
+    expenseType: 'variable',
+    createdBy: 'user-1',
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+  };
+}
+
+function makeReminder(id: string): VariableExpenseReminder {
+  return {
+    id,
+    amount: 12000,
+    dayOfMonth: 20,
+    category: 'other',
+    note: null,
+    payerUserId: 'user-1',
+  };
+}
+
+describe('useRecurringExpenseStore reminders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useRecurringExpenseStore.getState().reset();
+  });
+
+  it('DBへの月次非表示保存後にバナーから除去する', async () => {
+    useRecurringExpenseStore.setState({ variableReminders: [makeReminder('expense-1')] });
+
+    await useRecurringExpenseStore.getState().dismissReminder('expense-1');
+
+    expect(dismissVariableExpenseReminder).toHaveBeenCalledWith('expense-1');
+    expect(useRecurringExpenseStore.getState().variableReminders).toEqual([]);
+  });
+
+  it('定期支出を削除したら対応するバナーも除去する', async () => {
+    useRecurringExpenseStore.setState({
+      recurringExpenses: [makeExpense('expense-1')],
+      variableReminders: [makeReminder('expense-1')],
+    });
+
+    await useRecurringExpenseStore.getState().removeRecurringExpense('expense-1');
+
+    expect(useRecurringExpenseStore.getState().recurringExpenses).toEqual([]);
+    expect(useRecurringExpenseStore.getState().variableReminders).toEqual([]);
+  });
+});

--- a/apps/web/src/store/__tests__/useRecurringIncomeStore.test.ts
+++ b/apps/web/src/store/__tests__/useRecurringIncomeStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useRecurringIncomeStore } from '@/store/useRecurringIncomeStore';
 import type { IncomeReminder, RecurringIncome } from '@/types/transaction';
+import { dismissRecurringIncomeReminder } from '@/services/recurringIncomes';
 
 // Supabase に依存するサービス層をモックし、ストアのロジックのみを検証する。
 vi.mock('@/services/recurringIncomes', () => ({
@@ -9,6 +10,7 @@ vi.mock('@/services/recurringIncomes', () => ({
   updateRecurringIncome: vi.fn(),
   deleteRecurringIncome: vi.fn().mockResolvedValue(undefined),
   getIncomeReminders: vi.fn(),
+  dismissRecurringIncomeReminder: vi.fn().mockResolvedValue(undefined),
 }));
 
 function makeIncome(id: string): RecurringIncome {
@@ -57,5 +59,19 @@ describe('useRecurringIncomeStore.removeRecurringIncome', () => {
     // 削除済み収入のリマインダーがバナーに残らないこと（収入削除バグの原因B）
     expect(state.incomeReminders.map((reminder) => reminder.id)).toEqual(['inc-3']);
     expect(state.isSubmitting).toBe(false);
+  });
+});
+
+describe('useRecurringIncomeStore.dismissIncomeReminder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useRecurringIncomeStore.getState().reset();
+  });
+
+  it('DBへの月次非表示保存後にバナーから除去する', async () => {
+    useRecurringIncomeStore.setState({ incomeReminders: [makeReminder('inc-1')] });
+    await useRecurringIncomeStore.getState().dismissIncomeReminder('inc-1');
+    expect(dismissRecurringIncomeReminder).toHaveBeenCalledWith('inc-1');
+    expect(useRecurringIncomeStore.getState().incomeReminders).toEqual([]);
   });
 });

--- a/apps/web/src/store/useRecurringExpenseStore.ts
+++ b/apps/web/src/store/useRecurringExpenseStore.ts
@@ -14,6 +14,7 @@ import {
   generateMissingTransactions,
   generateFixedTransactionsByDate,
   getVariableExpenseReminders,
+  dismissVariableExpenseReminder,
 } from '@/services/recurringExpenses';
 
 /**
@@ -51,7 +52,9 @@ interface RecurringExpenseActions {
   /** 変動費リマインダーを読み込み */
   loadVariableReminders: (householdId: string) => Promise<void>;
   /** リマインダーを一時的に非表示 */
-  dismissReminder: (id: string) => void;
+  dismissReminder: (id: string) => Promise<void>;
+  /** 登録完了したリマインダーを即時除去 */
+  completeReminder: (id: string) => void;
   /** エラーをクリア */
   clearError: () => void;
   /** ストアをリセット */
@@ -148,9 +151,10 @@ export const useRecurringExpenseStore = create<RecurringExpenseStore>((set, get)
 
     try {
       await deleteRecurringExpense(id);
-      const { recurringExpenses } = get();
+      const { recurringExpenses, variableReminders } = get();
       set({
         recurringExpenses: recurringExpenses.filter((expense) => expense.id !== id),
+        variableReminders: variableReminders.filter((reminder) => reminder.id !== id),
         isSubmitting: false,
       });
     } catch (error) {
@@ -209,12 +213,21 @@ export const useRecurringExpenseStore = create<RecurringExpenseStore>((set, get)
   /**
    * リマインダーを一時的に非表示
    */
-  dismissReminder: (id: string) => {
-    const { variableReminders } = get();
-    set({
-      variableReminders: variableReminders.filter((r) => r.id !== id),
-    });
+  dismissReminder: async (id: string) => {
+    try {
+      await dismissVariableExpenseReminder(id);
+      set((state) => ({
+        variableReminders: state.variableReminders.filter((r) => r.id !== id),
+      }));
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'リマインダーを非表示にできませんでした' });
+    }
   },
+
+  completeReminder: (id: string) =>
+    set((state) => ({
+      variableReminders: state.variableReminders.filter((r) => r.id !== id),
+    })),
 
   /**
    * エラーをクリア

--- a/apps/web/src/store/useRecurringIncomeStore.ts
+++ b/apps/web/src/store/useRecurringIncomeStore.ts
@@ -12,6 +12,7 @@ import {
   updateRecurringIncome,
   deleteRecurringIncome,
   getIncomeReminders,
+  dismissRecurringIncomeReminder,
 } from '@/services/recurringIncomes';
 
 /**
@@ -45,7 +46,9 @@ interface RecurringIncomeActions {
   /** 収入リマインダーを読み込み */
   loadIncomeReminders: (householdId: string) => Promise<void>;
   /** リマインダーを一時的に非表示 */
-  dismissIncomeReminder: (id: string) => void;
+  dismissIncomeReminder: (id: string) => Promise<void>;
+  /** 登録完了したリマインダーを即時除去 */
+  completeIncomeReminder: (id: string) => void;
   /** エラーをクリア */
   clearError: () => void;
   /** ストアをリセット */
@@ -172,12 +175,21 @@ export const useRecurringIncomeStore = create<RecurringIncomeStore>((set, get) =
   /**
    * リマインダーを一時的に非表示
    */
-  dismissIncomeReminder: (id: string) => {
-    const { incomeReminders } = get();
-    set({
-      incomeReminders: incomeReminders.filter((r) => r.id !== id),
-    });
+  dismissIncomeReminder: async (id: string) => {
+    try {
+      await dismissRecurringIncomeReminder(id);
+      set((state) => ({
+        incomeReminders: state.incomeReminders.filter((r) => r.id !== id),
+      }));
+    } catch (error) {
+      set({ error: error instanceof Error ? error.message : 'リマインダーを非表示にできませんでした' });
+    }
   },
+
+  completeIncomeReminder: (id: string) =>
+    set((state) => ({
+      incomeReminders: state.incomeReminders.filter((r) => r.id !== id),
+    })),
 
   /**
    * エラーをクリア

--- a/apps/web/src/store/useSettlementStore.ts
+++ b/apps/web/src/store/useSettlementStore.ts
@@ -5,11 +5,17 @@
  */
 
 import { create } from 'zustand';
-import type { HouseholdBalance, Settlement, SettlementData } from '@/types/settlement';
+import type {
+  BalanceSettlementData,
+  HouseholdBalance,
+  Settlement,
+  SettlementData,
+} from '@/types/settlement';
 import {
   getHouseholdBalances,
   getSettlements,
   createSettlement,
+  createBalanceSettlement,
   deleteSettlement,
 } from '@/services/settlements';
 
@@ -39,6 +45,8 @@ interface SettlementStore {
   loadSettlements: (householdId: string) => Promise<void>;
   /** 精算を追加 */
   addSettlement: (data: SettlementData) => Promise<Settlement>;
+  /** 残高明細を安全に精算 */
+  settleBalance: (data: BalanceSettlementData) => Promise<Settlement>;
   /** 精算を削除 */
   removeSettlement: (id: string, householdId: string) => Promise<void>;
   /** エラーをクリア */
@@ -162,6 +170,27 @@ export const useSettlementStore = create<SettlementStore>((set) => {
         return settlement;
       } catch (error) {
         console.error('精算追加エラー:', error);
+        set({
+          error: error instanceof Error ? error.message : '精算の記録に失敗しました',
+          isSubmitting: false,
+        });
+        throw error;
+      }
+    },
+
+    settleBalance: async (data: BalanceSettlementData) => {
+      try {
+        set({ isSubmitting: true, error: null });
+        const settlement = await createBalanceSettlement(data);
+        set((state) => ({
+          settlements: [settlement, ...state.settlements],
+          isSubmitting: false,
+        }));
+
+        const balances = await getHouseholdBalances(data.householdId);
+        applyBalances(balances, true);
+        return settlement;
+      } catch (error) {
         set({
           error: error instanceof Error ? error.message : '精算の記録に失敗しました',
           isSubmitting: false,

--- a/apps/web/src/types/settlement.ts
+++ b/apps/web/src/types/settlement.ts
@@ -54,4 +54,31 @@ export interface HouseholdBalance {
   userName: string | null;
   /** 残高金額 (プラス: 受け取る, マイナス: 支払う) */
   balanceAmount: number;
+  /** 相手別の残高明細 */
+  breakdowns: HouseholdBalanceBreakdown[];
+}
+
+/**
+ * 相手別の立替残高。
+ * counterpartyUserId が null の場合は世帯全体との残高を表す。
+ */
+export interface HouseholdBalanceBreakdown {
+  subjectUserId: string;
+  subjectUserName: string | null;
+  counterpartyUserId: string | null;
+  counterpartyUserName: string | null;
+  /** プラス: 対象者が受け取る、マイナス: 対象者が支払う */
+  balanceAmount: number;
+  /** 過去の精算が元の立替残高を超えて反対符号になっている */
+  isOverSettled: boolean;
+}
+
+/** 残高明細に対する安全な精算入力 */
+export interface BalanceSettlementData {
+  householdId: string;
+  subjectUserId: string;
+  counterpartyUserId: string | null;
+  amount: number;
+  settledOn: string;
+  note?: string | null;
 }

--- a/apps/web/src/types/supabase.ts
+++ b/apps/web/src/types/supabase.ts
@@ -184,6 +184,7 @@ export type Database = {
           note: string | null
           payer_user_id: string
           updated_at: string | null
+          expense_type: string
         }
         Insert: {
           amount: number
@@ -197,6 +198,7 @@ export type Database = {
           note?: string | null
           payer_user_id: string
           updated_at?: string | null
+          expense_type?: string
         }
         Update: {
           amount?: number
@@ -210,6 +212,7 @@ export type Database = {
           note?: string | null
           payer_user_id?: string
           updated_at?: string | null
+          expense_type?: string
         }
         Relationships: [
           {
@@ -217,6 +220,48 @@ export type Database = {
             columns: ["household_id"]
             isOneToOne: false
             referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      recurring_reminder_dismissals: {
+        Row: {
+          created_at: string
+          dismissed_by: string
+          id: string
+          period_month: string
+          recurring_expense_id: string | null
+          recurring_income_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          dismissed_by: string
+          id?: string
+          period_month: string
+          recurring_expense_id?: string | null
+          recurring_income_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          dismissed_by?: string
+          id?: string
+          period_month?: string
+          recurring_expense_id?: string | null
+          recurring_income_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recurring_reminder_dismissals_recurring_expense_id_fkey"
+            columns: ["recurring_expense_id"]
+            isOneToOne: false
+            referencedRelation: "recurring_expenses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recurring_reminder_dismissals_recurring_income_id_fkey"
+            columns: ["recurring_income_id"]
+            isOneToOne: false
+            referencedRelation: "recurring_incomes"
             referencedColumns: ["id"]
           },
         ]
@@ -328,6 +373,8 @@ export type Database = {
           occurred_on: string
           payer_user_id: string | null
           place: string | null
+          recurring_expense_id: string | null
+          recurring_income_id: string | null
           type: Database["public"]["Enums"]["transaction_type"]
           updated_at: string | null
         }
@@ -343,6 +390,8 @@ export type Database = {
           occurred_on?: string
           payer_user_id?: string | null
           place?: string | null
+          recurring_expense_id?: string | null
+          recurring_income_id?: string | null
           type: Database["public"]["Enums"]["transaction_type"]
           updated_at?: string | null
         }
@@ -358,6 +407,8 @@ export type Database = {
           occurred_on?: string
           payer_user_id?: string | null
           place?: string | null
+          recurring_expense_id?: string | null
+          recurring_income_id?: string | null
           type?: Database["public"]["Enums"]["transaction_type"]
           updated_at?: string | null
         }
@@ -405,6 +456,36 @@ export type Database = {
           balance_amount: number
           user_id: string
           user_name: string
+        }[]
+      }
+      get_household_balance_breakdown: {
+        Args: { target_household: string }
+        Returns: {
+          subject_user_id: string
+          subject_user_name: string | null
+          counterparty_user_id: string | null
+          counterparty_user_name: string | null
+          balance_amount: number
+          is_over_settled: boolean
+        }[]
+      }
+      create_balance_settlement: {
+        Args: {
+          target_household: string
+          target_subject_user: string
+          target_counterparty_user: string | null
+          target_amount: number
+          target_settled_on: string
+          target_note?: string | null
+        }
+        Returns: Database["public"]["Tables"]["settlements"]["Row"][]
+      }
+      get_ranked_place_suggestions: {
+        Args: { target_household: string }
+        Returns: {
+          place: string
+          use_count: number
+          last_used_on: string
         }[]
       }
       is_household_member: {

--- a/apps/web/src/types/transaction.ts
+++ b/apps/web/src/types/transaction.ts
@@ -108,6 +108,10 @@ export interface TransactionData {
   advanceToUserId?: string | null;
   /** 場所（任意・支出/立替のみ） */
   place?: string | null;
+  /** リマインダー・自動生成元の定期支出ID */
+  recurringExpenseId?: string | null;
+  /** リマインダー元の定期収入ID */
+  recurringIncomeId?: string | null;
 }
 
 /**
@@ -133,6 +137,8 @@ export interface Transaction {
   /** 立替先ユーザーID */
   advanceToUserId: string | null;
   place: string | null;
+  recurringExpenseId: string | null;
+  recurringIncomeId: string | null;
   /** 作成者ユーザーID */
   createdBy: string;
   /** 作成日時 */
@@ -292,4 +298,11 @@ export interface IncomeReminder {
   note: string | null;
   /** 受取者ユーザーID */
   recipientUserId: string;
+}
+
+/** 過去に入力した場所の候補 */
+export interface PlaceSuggestion {
+  place: string;
+  useCount: number;
+  lastUsedOn: string;
 }

--- a/docs/superpowers/plans/2026-06-07-dev-test-login.md
+++ b/docs/superpowers/plans/2026-06-07-dev-test-login.md
@@ -1,0 +1,674 @@
+# ローカル開発用テストログイン & seed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ローカル開発時に dev 専用「テストログイン」ボタンと自動 seed スクリプトで、実データ付きの画面を最小手数で確認できるようにする（本番では完全無効）。
+
+**Architecture:** ホスト型 Supabase に専用テスト世帯とテストユーザー2名（夫婦）を seed スクリプトで投入し、`/auth` に `NEXT_PUBLIC_ENABLE_DEV_LOGIN` ガード付きのクイックログインボタンを追加。ボタンは実在テストユーザーで `signInWithPassword` を実行するため RLS を満たし、middleware を正規通過する。middleware・本番認証フローは無改変。
+
+**Tech Stack:** Next.js 15 (App Router) / TypeScript / Supabase (@supabase/supabase-js) / Zustand / Vitest + React Testing Library / tsx + dotenv（seed 実行用）
+
+参照 spec: `docs/superpowers/specs/2026-06-07-dev-test-login-design.md`
+
+## 確認済みの前提（実装時の事実）
+
+- カテゴリは英語キー。支出: `groceries, dining, daily, medical, home, kids, transportation, fixed, other`。収入: `salary, sideline, windfall, subsidy`。
+- `transactions` の DB カラム（snake_case）: `household_id, type('expense'|'income'|'advance'), amount(NUMERIC>0), occurred_on(date), category, note, payer_user_id, advance_to_user_id, place(nullable text), created_by`。
+- `settlements` の DB カラム: `household_id, from_user_id, to_user_id, amount(>0), settled_on(date), note, created_by`。
+- `household_members`: `household_id, user_id(→profiles.id), role('owner'|'member')`、`UNIQUE(household_id, user_id)`。
+- `households`: `id, name, owner_user_id`。
+- `on_auth_user_created` トリガーが auth ユーザー作成時に `profiles` を自動生成（`user_metadata.name` を採用）。**seed で profiles を直接 insert する必要なし。**
+- service role クライアントは RLS をバイパスする。
+- ログイン後遷移は既存 SignInForm 準拠: `router.push('/'); router.refresh();`。
+- テスト基盤: Vitest（jsdom, globals:true）、`@testing-library/jest-dom/vitest` 登録済み、`@` エイリアス = `src/`。
+
+## ファイル構成
+
+- 新規 `apps/web/scripts/seed-test-data.ts` — service role でテストユーザー/世帯/取引/精算を冪等投入。
+- 新規 `apps/web/src/components/auth/DevLoginButton.tsx` — dev 専用クイックログイン UI。
+- 新規 `apps/web/src/components/auth/__tests__/DevLoginButton.test.tsx` — 上記の単体テスト。
+- 新規 `apps/web/.env.example` — 全 env キーの placeholder。
+- 変更 `apps/web/src/app/auth/page.tsx` — signin タブに DevLoginButton を差し込む。
+- 変更 `apps/web/package.json` — `seed:test` script と `tsx`/`dotenv` devDependency。
+- 変更 `CLAUDE.md` — ローカル開発手順（seed → dev-login）を追記。
+- 変更（コミット対象外）`apps/web/.env.local` — dev-login 用キーを追加（手動）。
+
+---
+
+### Task 1: seed 実行ツール（tsx / dotenv）と npm script を追加
+
+**Files:**
+- Modify: `apps/web/package.json`
+
+- [ ] **Step 1: devDependency と script を追加**
+
+`apps/web/package.json` の `"scripts"` に次の1行を追加（`test:coverage` の後など）:
+
+```json
+    "seed:test": "tsx scripts/seed-test-data.ts"
+```
+
+`"devDependencies"` に次の2つを追加（アルファベット順の位置でよい）:
+
+```json
+    "dotenv": "^16.4.7",
+    "tsx": "^4.19.2",
+```
+
+- [ ] **Step 2: インストール**
+
+Run: `pnpm install`
+Expected: `dotenv` と `tsx` が追加され、`apps/web/node_modules/.bin/tsx` が存在する。
+
+確認: `ls apps/web/node_modules/.bin/tsx` → パスが表示される。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/package.json pnpm-lock.yaml
+git commit -m "chore: seed 実行用に tsx/dotenv と seed:test script を追加"
+```
+
+---
+
+### Task 2: `.env.example` を作成し env キーを定義
+
+**Files:**
+- Create: `apps/web/.env.example`
+
+- [ ] **Step 1: `.env.example` を作成**
+
+```bash
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# サーバー専用（seed スクリプト等）。絶対に公開しない
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# 開発用テストログイン（ローカルのみ true。Vercel など本番では未設定にすること）
+NEXT_PUBLIC_ENABLE_DEV_LOGIN=false
+NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL=test-taro@example.com
+NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD=devpassword123
+NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL=test-hanako@example.com
+NEXT_PUBLIC_DEV_LOGIN_HANAKO_PASSWORD=devpassword123
+```
+
+- [ ] **Step 2: `.env.local`（手動・コミット対象外）に dev-login キーを追記**
+
+既存の `apps/web/.env.local` に以下を追記する（`SUPABASE_SERVICE_ROLE_KEY` が無ければ Supabase ダッシュボードの値を設定）:
+
+```bash
+NEXT_PUBLIC_ENABLE_DEV_LOGIN=true
+NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL=test-taro@example.com
+NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD=devpassword123
+NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL=test-hanako@example.com
+NEXT_PUBLIC_DEV_LOGIN_HANAKO_PASSWORD=devpassword123
+```
+
+確認: `git status` に `apps/web/.env.local` が出ないこと（`.gitignore` 対象）。出る場合は無視する（add しない）。
+
+- [ ] **Step 3: Commit（`.env.example` のみ）**
+
+```bash
+git add apps/web/.env.example
+git commit -m "docs: .env.example を追加し dev-login 用キーを記載"
+```
+
+---
+
+### Task 3: DevLoginButton コンポーネント（TDD）
+
+**Files:**
+- Test: `apps/web/src/components/auth/__tests__/DevLoginButton.test.tsx`
+- Create: `apps/web/src/components/auth/DevLoginButton.tsx`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`apps/web/src/components/auth/__tests__/DevLoginButton.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DevLoginButton } from '../DevLoginButton';
+
+const pushMock = vi.fn();
+const refreshMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+const signInMock = vi.fn();
+vi.mock('@/store/useAuthStore', () => ({
+  useAuthStore: (selector: (s: { signIn: typeof signInMock }) => unknown) =>
+    selector({ signIn: signInMock }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe('DevLoginButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signInMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('フラグが未設定なら何も描画しない', () => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_DEV_LOGIN', '');
+    const { container } = render(<DevLoginButton />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('フラグ on で2つのテストログインボタンを描画する', () => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_DEV_LOGIN', 'true');
+    render(<DevLoginButton />);
+    expect(
+      screen.getByRole('button', { name: 'テスト太郎でログイン' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'テスト花子でログイン' })
+    ).toBeInTheDocument();
+  });
+
+  it('ボタンクリックで正しい資格情報で signIn を呼び / に遷移する', async () => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_DEV_LOGIN', 'true');
+    vi.stubEnv('NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL', 'test-taro@example.com');
+    vi.stubEnv('NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD', 'devpassword123');
+    const user = userEvent.setup();
+    render(<DevLoginButton />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'テスト太郎でログイン' })
+    );
+
+    expect(signInMock).toHaveBeenCalledWith(
+      'test-taro@example.com',
+      'devpassword123'
+    );
+    expect(pushMock).toHaveBeenCalledWith('/');
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  it('資格情報が未設定のボタンは signIn を呼ばずエラー通知する', async () => {
+    vi.stubEnv('NEXT_PUBLIC_ENABLE_DEV_LOGIN', 'true');
+    // HANAKO の env を設定しないのでクリックしても signIn は呼ばれない
+    const user = userEvent.setup();
+    render(<DevLoginButton />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'テスト花子でログイン' })
+    );
+
+    expect(signInMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `pnpm --filter web test --run src/components/auth/__tests__/DevLoginButton.test.tsx`
+Expected: FAIL（`DevLoginButton` モジュールが存在しない / import 解決エラー）。
+
+- [ ] **Step 3: 最小実装を書く**
+
+`apps/web/src/components/auth/DevLoginButton.tsx`:
+
+```tsx
+/**
+ * 開発用テストログインボタン
+ *
+ * ローカル開発時のみ表示し、env に設定したテストアカウントで即ログインする。
+ * `NEXT_PUBLIC_ENABLE_DEV_LOGIN === 'true'` のときだけ描画され、
+ * 本番（Vercel 等）では env 未設定のため何も描画されず資格情報もバンドルに残らない。
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { useAuthStore } from '@/store/useAuthStore';
+
+/** テストアカウント定義 */
+interface DevAccount {
+  /** ボタン表示名 */
+  label: string;
+  /** メールアドレス（env から取得・未設定なら undefined） */
+  email?: string;
+  /** パスワード（env から取得・未設定なら undefined） */
+  password?: string;
+}
+
+/**
+ * 開発用テストログインボタン群
+ *
+ * @returns dev-login が有効なときのみボタン群、そうでなければ null
+ */
+export function DevLoginButton() {
+  const router = useRouter();
+  const signIn = useAuthStore((state) => state.signIn);
+  const [loadingLabel, setLoadingLabel] = useState<string | null>(null);
+
+  if (process.env.NEXT_PUBLIC_ENABLE_DEV_LOGIN !== 'true') {
+    return null;
+  }
+
+  const accounts: DevAccount[] = [
+    {
+      label: 'テスト太郎でログイン',
+      email: process.env.NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL,
+      password: process.env.NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD,
+    },
+    {
+      label: 'テスト花子でログイン',
+      email: process.env.NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL,
+      password: process.env.NEXT_PUBLIC_DEV_LOGIN_HANAKO_PASSWORD,
+    },
+  ];
+
+  const handleLogin = async (account: DevAccount) => {
+    if (!account.email || !account.password) {
+      toast.error('テストアカウントの資格情報が未設定です（.env.local を確認）');
+      return;
+    }
+    try {
+      setLoadingLabel(account.label);
+      await signIn(account.email, account.password);
+      toast.success('テストログインしました');
+      router.push('/');
+      router.refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'テストログインに失敗しました'
+      );
+    } finally {
+      setLoadingLabel(null);
+    }
+  };
+
+  return (
+    <div className="mt-6 space-y-2 border-t pt-4">
+      <p className="text-center text-xs text-muted-foreground">
+        開発用テストログイン
+      </p>
+      {accounts.map((account) => (
+        <Button
+          key={account.label}
+          type="button"
+          variant="outline"
+          className="w-full"
+          disabled={loadingLabel !== null}
+          onClick={() => handleLogin(account)}
+        >
+          {loadingLabel === account.label ? 'ログイン中...' : account.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `pnpm --filter web test --run src/components/auth/__tests__/DevLoginButton.test.tsx`
+Expected: PASS（4 件）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/auth/DevLoginButton.tsx apps/web/src/components/auth/__tests__/DevLoginButton.test.tsx
+git commit -m "feat: dev 専用テストログインボタンを追加"
+```
+
+---
+
+### Task 4: `/auth` ページに DevLoginButton を差し込む
+
+**Files:**
+- Modify: `apps/web/src/app/auth/page.tsx`
+
+- [ ] **Step 1: import を追加**
+
+`apps/web/src/app/auth/page.tsx` の import 群（`SignUpForm` の import の下）に追加:
+
+```tsx
+import { DevLoginButton } from '@/components/auth/DevLoginButton';
+```
+
+- [ ] **Step 2: signin タブの SignInForm 直下に差し込む**
+
+signin タブの `<CardContent>` 内、`<SignInForm />` の直後に追加:
+
+```tsx
+              <CardContent>
+                <SignInForm />
+                <DevLoginButton />
+              </CardContent>
+```
+
+- [ ] **Step 3: dev で表示を目視確認**
+
+Run: `pnpm --filter web dev`
+ブラウザで `http://localhost:3000/auth` を開く。
+Expected: サインインフォーム下に「開発用テストログイン」区切りと2ボタンが表示される（`.env.local` の `NEXT_PUBLIC_ENABLE_DEV_LOGIN=true` 前提）。確認後 dev サーバーを停止。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/auth/page.tsx
+git commit -m "feat: /auth にテストログインボタンを差し込み"
+```
+
+---
+
+### Task 5: seed スクリプトを作成
+
+**Files:**
+- Create: `apps/web/scripts/seed-test-data.ts`
+
+- [ ] **Step 1: スクリプトを作成**
+
+`apps/web/scripts/seed-test-data.ts`:
+
+```ts
+/**
+ * テストデータ seed スクリプト（ローカル開発用）
+ *
+ * service role でホスト型 Supabase に「テスト世帯」とテストユーザー2名（夫婦）、
+ * 代表的な取引・精算を冪等に投入する。再実行するとテスト世帯の取引/精算を
+ * 入れ替えて同じ状態に戻す。
+ *
+ * 実行: pnpm --filter web seed:test
+ * 投入内容の確認のみ: pnpm --filter web seed:test -- --dry-run
+ */
+
+import { config } from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const DRY_RUN = process.argv.includes('--dry-run');
+
+/** テスト世帯の固定 UUID（冪等な特定に使用） */
+const TEST_HOUSEHOLD_ID = '00000000-0000-4000-8000-000000000001';
+
+const TARO = {
+  email: process.env.NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL ?? 'test-taro@example.com',
+  password:
+    process.env.NEXT_PUBLIC_DEV_LOGIN_TARO_PASSWORD ?? 'devpassword123',
+  name: 'テスト太郎',
+};
+const HANAKO = {
+  email:
+    process.env.NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL ?? 'test-hanako@example.com',
+  password:
+    process.env.NEXT_PUBLIC_DEV_LOGIN_HANAKO_PASSWORD ?? 'devpassword123',
+  name: 'テスト花子',
+};
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  console.error(
+    'NEXT_PUBLIC_SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY を .env.local に設定してください'
+  );
+  process.exit(1);
+}
+
+const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+/** メールから既存ユーザーを探し、無ければ作成して id を返す */
+async function ensureUser(account: {
+  email: string;
+  password: string;
+  name: string;
+}): Promise<string> {
+  const { data: list, error: listError } = await admin.auth.admin.listUsers({
+    page: 1,
+    perPage: 1000,
+  });
+  if (listError) throw listError;
+
+  const existing = list.users.find((u) => u.email === account.email);
+  if (existing) {
+    console.log(`  user 既存: ${account.email} (${existing.id})`);
+    return existing.id;
+  }
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email: account.email,
+    password: account.password,
+    email_confirm: true,
+    user_metadata: { name: account.name },
+  });
+  if (error) throw error;
+  console.log(`  user 作成: ${account.email} (${data.user.id})`);
+  return data.user.id;
+}
+
+/** 1日前/数日前などの日付文字列(YYYY-MM-DD)を返す */
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+async function main() {
+  console.log(DRY_RUN ? '[dry-run] 投入内容のプレビュー' : 'seed 開始');
+
+  // 1. ユーザー
+  console.log('1. テストユーザー');
+  if (DRY_RUN) {
+    console.log(`  ${TARO.email} (owner), ${HANAKO.email} (member)`);
+  }
+  const taroId = DRY_RUN ? 'taro-id' : await ensureUser(TARO);
+  const hanakoId = DRY_RUN ? 'hanako-id' : await ensureUser(HANAKO);
+
+  // 2. テスト世帯（固定 UUID で find-or-create）
+  console.log('2. テスト世帯');
+  if (!DRY_RUN) {
+    const { data: hh } = await admin
+      .from('households')
+      .select('id')
+      .eq('id', TEST_HOUSEHOLD_ID)
+      .maybeSingle();
+    if (!hh) {
+      const { error } = await admin.from('households').insert({
+        id: TEST_HOUSEHOLD_ID,
+        name: 'テスト世帯',
+        owner_user_id: taroId,
+      });
+      if (error) throw error;
+      console.log('  世帯 作成: テスト世帯');
+    } else {
+      console.log('  世帯 既存: テスト世帯');
+    }
+
+    // 3. メンバー
+    const { error: memberError } = await admin
+      .from('household_members')
+      .upsert(
+        [
+          {
+            household_id: TEST_HOUSEHOLD_ID,
+            user_id: taroId,
+            role: 'owner',
+          },
+          {
+            household_id: TEST_HOUSEHOLD_ID,
+            user_id: hanakoId,
+            role: 'member',
+          },
+        ],
+        { onConflict: 'household_id,user_id' }
+      );
+    if (memberError) throw memberError;
+    console.log('3. メンバー upsert 完了');
+  }
+
+  // 4. 取引・精算（テスト世帯ぶんを入れ替え）
+  console.log('4. 取引・精算');
+  const transactions = [
+    // 支出（各カテゴリ）
+    { type: 'expense', amount: 5200, category: 'groceries', occurred_on: daysAgo(2), note: 'スーパー', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 3800, category: 'dining', occurred_on: daysAgo(3), note: 'ランチ', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 1500, category: 'daily', occurred_on: daysAgo(5), note: '日用品', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 2200, category: 'medical', occurred_on: daysAgo(7), note: '薬', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 18000, category: 'home', occurred_on: daysAgo(10), note: '家電', payer_user_id: taroId, created_by: taroId },
+    { type: 'expense', amount: 4300, category: 'kids', occurred_on: daysAgo(12), note: '子ども用品', payer_user_id: hanakoId, created_by: hanakoId },
+    { type: 'expense', amount: 980, category: 'other', occurred_on: daysAgo(14), note: 'その他', payer_user_id: taroId, created_by: taroId },
+    // 収入
+    { type: 'income', amount: 280000, category: 'salary', occurred_on: daysAgo(1), note: '給料', payer_user_id: taroId, created_by: taroId },
+    { type: 'income', amount: 60000, category: 'sideline', occurred_on: daysAgo(6), note: '副業', payer_user_id: hanakoId, created_by: hanakoId },
+    // 立替（世帯: advance_to_user_id = null）
+    { type: 'advance', amount: 90000, category: 'home', occurred_on: daysAgo(8), note: '家賃立替', payer_user_id: taroId, advance_to_user_id: null, created_by: taroId },
+    // 立替（個人: advance_to_user_id = 花子）
+    { type: 'advance', amount: 7000, category: 'other', occurred_on: daysAgo(4), note: '花子の買い物立替', payer_user_id: taroId, advance_to_user_id: hanakoId, created_by: taroId },
+  ].map((t) => ({ household_id: TEST_HOUSEHOLD_ID, ...t }));
+
+  const settlements = [
+    { household_id: TEST_HOUSEHOLD_ID, from_user_id: hanakoId, to_user_id: taroId, amount: 3000, settled_on: daysAgo(1), note: '一部精算', created_by: hanakoId },
+  ];
+
+  if (DRY_RUN) {
+    console.log(`  transactions: ${transactions.length} 件`);
+    console.log(`  settlements: ${settlements.length} 件`);
+    console.log('[dry-run] DB は変更していません');
+    return;
+  }
+
+  // 既存テスト世帯ぶんを削除してから再投入
+  const { error: delSettle } = await admin
+    .from('settlements')
+    .delete()
+    .eq('household_id', TEST_HOUSEHOLD_ID);
+  if (delSettle) throw delSettle;
+  const { error: delTx } = await admin
+    .from('transactions')
+    .delete()
+    .eq('household_id', TEST_HOUSEHOLD_ID);
+  if (delTx) throw delTx;
+
+  const { error: txError } = await admin.from('transactions').insert(transactions);
+  if (txError) throw txError;
+  const { error: settleError } = await admin.from('settlements').insert(settlements);
+  if (settleError) throw settleError;
+
+  console.log(
+    `  取引 ${transactions.length} 件 / 精算 ${settlements.length} 件 投入完了`
+  );
+  console.log('seed 完了');
+}
+
+main().catch((err) => {
+  console.error('seed 失敗:', err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: dry-run で投入内容を確認**
+
+Run: `pnpm --filter web seed:test -- --dry-run`
+Expected: エラーなく `transactions: 11 件` / `settlements: 1 件` / `[dry-run] DB は変更していません` が表示される。
+
+- [ ] **Step 3: 本番投入を実行**
+
+Run: `pnpm --filter web seed:test`
+Expected: `user 作成`（初回）または `user 既存`（再実行）、`取引 11 件 / 精算 1 件 投入完了`、`seed 完了` が表示される。
+
+- [ ] **Step 4: 冪等性を確認（再実行）**
+
+Run: `pnpm --filter web seed:test`
+Expected: `user 既存` / `世帯 既存` となり、取引・精算は重複せず 11 件 / 1 件のまま（エラーなし）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/scripts/seed-test-data.ts
+git commit -m "feat: テストデータ seed スクリプトを追加"
+```
+
+---
+
+### Task 6: ローカル開発手順を CLAUDE.md に追記
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: 手順セクションを追記**
+
+`CLAUDE.md` の `## Environment Variables` セクションの直後に、以下のセクションを追加:
+
+```markdown
+## ローカル開発用テストログイン
+
+ローカルで実データ付きの画面を確認するための仕組み（本番では無効）。
+
+1. `apps/web/.env.local` に以下を設定:
+   - `SUPABASE_SERVICE_ROLE_KEY`（seed 用）
+   - `NEXT_PUBLIC_ENABLE_DEV_LOGIN=true`
+   - `NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL` / `_PASSWORD`, `NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL` / `_PASSWORD`
+2. テストデータを投入: `pnpm --filter web seed:test`（`-- --dry-run` で確認のみ）
+3. `pnpm --filter web dev` で起動し `/auth` を開く
+4. 「テスト太郎でログイン」/「テスト花子でログイン」で即ログイン
+
+**本番安全性**: dev-login は `NEXT_PUBLIC_ENABLE_DEV_LOGIN === 'true'` のときだけ描画される。
+Vercel など本番ではこの変数と資格情報変数を設定しないこと（未設定ならボタンは出ず、資格情報もバンドルされない）。
+
+**テストアカウントの削除**: 不要になったら Supabase ダッシュボードの Authentication からテストユーザー
+（`@example.com`）を削除し、`households` の「テスト世帯」（固定 UUID `00000000-0000-4000-8000-000000000001`）を削除する。
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: ローカル開発用テストログインの手順を追記"
+```
+
+---
+
+### Task 7: 最終検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: lint**
+
+Run: `pnpm --filter web lint`
+Expected: エラーなし。
+
+- [ ] **Step 2: type-check**
+
+Run: `pnpm --filter web type-check`
+Expected: エラーなし。
+
+- [ ] **Step 3: 全テスト**
+
+Run: `pnpm --filter web test`
+Expected: 全テスト PASS（DevLoginButton 4 件を含む）。
+
+- [ ] **Step 4: build**
+
+Run: `pnpm --filter web build`
+Expected: ビルド成功。
+
+- [ ] **Step 5: 本番ガードの目視確認**
+
+`apps/web/.env.local` の `NEXT_PUBLIC_ENABLE_DEV_LOGIN` を一時的に `false` にして `pnpm --filter web dev` を起動し、
+`/auth` にテストログインボタンが**表示されない**ことを確認。確認後 `true` に戻す。
+
+---
+
+## Self-Review メモ
+
+- spec の全要素（seed/DevLoginButton/env.example/auth差し込み/本番ガード/テスト/ドキュメント）に対応タスクあり。
+- カテゴリキー・DB カラム名・型・関数名はコード調査で確定済みの値に統一。
+- プレースホルダ無し（全ステップに実コード・実コマンド・期待出力あり）。

--- a/docs/superpowers/specs/2026-06-07-dev-test-login-design.md
+++ b/docs/superpowers/specs/2026-06-07-dev-test-login-design.md
@@ -1,0 +1,114 @@
+# ローカル開発用テストログイン & seed 設計
+
+- 日付: 2026-06-07
+- ブランチ: `feature/dev-test-login`
+- 起点: `main`
+
+## 背景・課題
+
+ローカル開発時、`middleware.ts` が全ルートを認証ガードしており、ログインしないと画面を確認できない。
+さらに全データは Supabase の RLS 下にあるため、**単に「ログイン不要」にしても有効なセッションが無いとデータが返らず空画面になる**。
+
+接続先は**ホスト型 Supabase**（`*.supabase.co`）。ローカル Supabase 設定（`supabase/config.toml`）は存在するが未使用。
+
+## ゴール
+
+ローカルで「実データを含む画面全体」を最小手数で確認できるようにする。
+**本番（Vercel）では一切無効化されること**を必須とする。
+
+## 採用方針
+
+dev 専用のクイックログインボタン + 自動 seed スクリプト（ホスト型 DB に専用テスト世帯）。
+
+- 実在のテストユーザーで `signInWithPassword` を実行 → 本物のセッションが張られ RLS を満たす。
+- **middleware・本番認証フローには一切手を入れない**（認証バイパスではなく「正規ログインの省力化」）。
+
+### 却下した案
+- **middleware バイパス**: RLS でデータが返らず空画面になり、目的（実データ確認）を満たさない。
+- **ローカル Supabase + seed**: 隔離性は高いが Docker 起動が必要。今回は「ホスト型に専用世帯」を選択。
+
+## 前提（確認済みスキーマ事実）
+
+- `on_auth_user_created` トリガー → `handle_new_user()` が auth ユーザー作成時に `profiles` を自動生成
+  （`raw_user_meta_data->>'name'` を name に採用）。**seed で profiles を直接挿入する必要は無い。**
+- `household_members.user_id` は `profiles(id)` を参照。`role` は `'owner' | 'member'`。
+- `transactions` カラム: `household_id, type(enum: expense|income|advance), amount(>0), occurred_on(date), category, note, payer_user_id, advance_to_user_id, created_by`。
+- `settlements` カラム: `household_id, from_user_id, to_user_id, amount(>0), settled_on(date), note, created_by`。
+- ログイン後遷移パターン（既存 SignInForm 準拠）: `router.push('/'); router.refresh();`。
+
+## コンポーネント設計
+
+### 1. seed スクリプト `apps/web/scripts/seed-test-data.ts`
+
+- `.env.local` から `NEXT_PUBLIC_SUPABASE_URL` と `SUPABASE_SERVICE_ROLE_KEY` を読み込む（`dotenv`）。
+- service role クライアントで以下を冪等に投入:
+  1. テストユーザー2名（夫婦）を `auth.admin.createUser({ email_confirm: true, user_metadata: { name } })` で作成
+     - 太郎: `test-taro@example.com`（owner）
+     - 花子: `test-hanako@example.com`（member）
+     - 既存なら作成せず取得（list でメールを引く）。
+     - profiles はトリガーが自動生成。
+  2. 固定 UUID の「テスト世帯」を find-or-create（`owner_user_id` = 太郎）。
+  3. `household_members` に太郎(owner)・花子(member) を upsert（`UNIQUE(household_id, user_id)` 利用）。
+  4. 代表的な取引を投入:
+     - 各カテゴリ（食費/外食費/日用品/医療費/家具・家電/子ども/その他）の支出を数件
+     - 収入を数件
+     - 世帯立替（`advance_to_user_id = NULL`）1件、個人立替（`advance_to_user_id` 指定）1件
+     - 精算 1件
+- **冪等性**: テスト世帯を固定 UUID で特定し、再実行時はその世帯の `transactions` / `settlements` を削除してから再投入。何度でも同じ状態に戻せる。
+- `--dry-run` フラグ: 投入内容をログ出力するのみで DB を変更しない。
+- 実行: `pnpm --filter web seed:test`（`package.json` に `"seed:test": "tsx scripts/seed-test-data.ts"` を追加、`tsx` を devDependency に追加）。
+- このスクリプトはアプリ本体から import されない（手動実行のみ）。
+
+### 2. dev クイックログイン UI `apps/web/src/components/auth/DevLoginButton.tsx`
+
+- `'use client'`。表示ガード: `process.env.NEXT_PUBLIC_ENABLE_DEV_LOGIN === 'true'` のときのみレンダリング。false/未設定なら `null` を返す。
+- 「テスト太郎でログイン」「テスト花子でログイン」の2ボタン（2人精算フロー確認のため）。
+- クリックで `useAuthStore.signIn(email, password)` → 成功後 `router.push('/'); router.refresh();`。
+- 資格情報は `NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL` / `..._TARO_PASSWORD` / `..._HANAKO_EMAIL` / `..._HANAKO_PASSWORD` から取得。
+- `/auth` の SignInForm 下に区切り線付きで差し込む（`app/auth/page.tsx` の signin タブ内）。
+
+### 3. env / ドキュメント
+
+- 不足している `apps/web/.env.example` を新規作成し、全キーを placeholder 付きで記載:
+  - `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+  - `NEXT_PUBLIC_ENABLE_DEV_LOGIN`, `NEXT_PUBLIC_DEV_LOGIN_TARO_EMAIL/PASSWORD`, `NEXT_PUBLIC_DEV_LOGIN_HANAKO_EMAIL/PASSWORD`
+- CLAUDE.md（または README）に「`pnpm seed:test` → `pnpm dev` → /auth でテストログイン」のローカル手順とテストアカウント削除手順を追記。
+
+## データフロー
+
+1. `pnpm --filter web seed:test`（初回のみ）→ テストユーザー・世帯・サンプルデータが投入される。
+2. `pnpm --filter web dev` で起動、`/auth` を開く。
+3. `NEXT_PUBLIC_ENABLE_DEV_LOGIN=true` なので「テスト太郎/花子でログイン」ボタンが表示。
+4. クリック → 実セッション発行 → middleware を正規通過 → 実データ付きダッシュボード表示。
+
+## 本番安全性（最重要）
+
+- dev-login 関連コードは全て `NEXT_PUBLIC_ENABLE_DEV_LOGIN === 'true'` ガード下。
+- Vercel ではこの変数も資格情報変数も**未設定** → ボタンは描画されず、`process.env.NEXT_PUBLIC_*` はビルド時に `undefined` として inline されるため資格情報はバンドルに漏れない。
+- `middleware.ts` は無改変 → 認証バイパスは存在しない。
+- seed スクリプトは `SUPABASE_SERVICE_ROLE_KEY` を要求し手動実行のみ。アプリから import しない。
+- テストアカウントは `@example.com` + 専用世帯で識別可能。削除手順をドキュメント化。
+
+## テスト方針
+
+- `DevLoginButton.test.tsx`（Vitest + RTL）:
+  - フラグ on で2ボタンが描画される / off で `null`（何も描画しない）。
+  - ボタンクリックで `signIn` が正しい資格情報で呼ばれる（`useAuthStore`・`next/navigation` をモック）。
+- seed スクリプトはネットワーク依存のため単体テスト対象外。`--dry-run` で投入内容を検証可能にする。
+
+## 影響範囲（変更/新規ファイル）
+
+- 新規: `apps/web/scripts/seed-test-data.ts`
+- 新規: `apps/web/src/components/auth/DevLoginButton.tsx`
+- 新規: `apps/web/src/components/auth/DevLoginButton.test.tsx`
+- 新規: `apps/web/.env.example`
+- 変更: `apps/web/src/app/auth/page.tsx`（DevLoginButton 差し込み）
+- 変更: `apps/web/package.json`（`seed:test` script + `tsx` devDependency）
+- 変更: `CLAUDE.md` または `README`（ローカル手順追記）
+- 変更: `apps/web/.env.local`（dev-login 用キーを追加。コミット対象外）
+
+## 未確定・実装時に確認する点
+
+- `tsx` を使うか `node --import tsx` 形式にするか（pnpm 環境で動く方を採用）。
+- サンプル取引の件数・金額の具体値（実装時に「それらしい」値を設定）。
+- テスト世帯の固定 UUID 値の決定。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 0.545.0(react@19.1.0)
       next:
         specifier: 15.5.9
-        version: 15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.5.9(@playwright/test@1.62.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -80,6 +80,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.62.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.14
@@ -695,6 +698,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2455,6 +2463,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3080,6 +3093,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4165,6 +4188,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6114,6 +6141,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6589,7 +6619,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.5.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.5.9(@playwright/test@1.62.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.5.9
       '@swc/helpers': 0.5.15
@@ -6607,6 +6637,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.7
       '@next/swc-win32-arm64-msvc': 15.5.7
       '@next/swc-win32-x64-msvc': 15.5.7
+      '@playwright/test': 1.62.0
       sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -6702,6 +6733,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,10 @@ importers:
         version: 19.2.1(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@20.19.21)(jiti@2.6.1))
+        version: 6.0.2(vite@8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4))
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
       eslint:
         specifier: ^9
         version: 9.37.0(jiti@2.6.1)
@@ -119,6 +122,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.14
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -127,7 +133,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@20.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.21)(jiti@2.6.1))
+        version: 4.1.8(@types/node@20.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4))
 
 packages:
 
@@ -222,6 +228,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -2053,6 +2215,10 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2105,6 +2271,11 @@ packages:
 
   es-toolkit@1.40.0:
     resolution: {integrity: sha512-8o6w0KFmU0CiIl0/Q/BCEOabF2IJaELM1T2PWj6e8KqzHv1gdx+7JtFnDwOx1kJH/isJ5NwlDG1nCr1HrRF94Q==}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3306,6 +3477,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -3657,6 +3833,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@2.6.1))':
@@ -5103,10 +5357,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@20.19.21)(jiti@2.6.1))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@20.19.21)(jiti@2.6.1)
+      vite: 8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -5117,13 +5371,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.21)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@20.19.21)(jiti@2.6.1)
+      vite: 8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5452,6 +5706,8 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dotenv@16.6.1: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5571,6 +5827,35 @@ snapshots:
       is-symbol: 1.1.1
 
   es-toolkit@1.40.0: {}
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escape-string-regexp@4.0.0: {}
 
@@ -6939,6 +7224,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
@@ -7055,7 +7346,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.16(@types/node@20.19.21)(jiti@2.6.1):
+  vite@8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7064,13 +7355,15 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.21
+      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.22.4
 
-  vitest@4.1.8(@types/node@20.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.21)(jiti@2.6.1)):
+  vitest@4.1.8(@types/node@20.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.21)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -7087,7 +7380,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@20.19.21)(jiti@2.6.1)
+      vite: 8.0.16(@types/node@20.19.21)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.21

--- a/supabase/sql/010_balance_breakdown_and_safe_settlement.sql
+++ b/supabase/sql/010_balance_breakdown_and_safe_settlement.sql
@@ -1,0 +1,322 @@
+-- 010_balance_breakdown_and_safe_settlement.sql
+-- 立替残高を相手別に分解し、残高を超えない安全な精算RPCを追加する。
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_household_balance_breakdown(
+  target_household UUID
+)
+RETURNS TABLE (
+  subject_user_id UUID,
+  subject_user_name TEXT,
+  counterparty_user_id UUID,
+  counterparty_user_name TEXT,
+  balance_amount NUMERIC,
+  is_over_settled BOOLEAN
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.is_household_member(target_household) THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  WITH ledger_entries AS (
+    -- 立替をした人は相手から受け取る（プラス）
+    SELECT
+      t.payer_user_id AS subject_id,
+      t.advance_to_user_id AS counterparty_id,
+      t.amount AS advance_amount,
+      0::NUMERIC AS settlement_amount
+    FROM public.transactions t
+    WHERE t.household_id = target_household
+      AND t.type = 'advance'
+      AND t.payer_user_id IS NOT NULL
+
+    UNION ALL
+
+    -- 個人向け立替では、立替先に反対符号の残高を持たせる
+    SELECT
+      t.advance_to_user_id AS subject_id,
+      t.payer_user_id AS counterparty_id,
+      -t.amount AS advance_amount,
+      0::NUMERIC AS settlement_amount
+    FROM public.transactions t
+    WHERE t.household_id = target_household
+      AND t.type = 'advance'
+      AND t.payer_user_id IS NOT NULL
+      AND t.advance_to_user_id IS NOT NULL
+
+    UNION ALL
+
+    -- 支払った側は負債が減る（残高へプラス）
+    SELECT
+      s.from_user_id AS subject_id,
+      s.to_user_id AS counterparty_id,
+      0::NUMERIC AS advance_amount,
+      s.amount AS settlement_amount
+    FROM public.settlements s
+    WHERE s.household_id = target_household
+      AND s.from_user_id IS NOT NULL
+
+    UNION ALL
+
+    -- 受け取った側は債権が減る（残高へマイナス）
+    SELECT
+      s.to_user_id AS subject_id,
+      s.from_user_id AS counterparty_id,
+      0::NUMERIC AS advance_amount,
+      -s.amount AS settlement_amount
+    FROM public.settlements s
+    WHERE s.household_id = target_household
+      AND s.to_user_id IS NOT NULL
+  ), aggregated AS (
+    SELECT
+      le.subject_id,
+      le.counterparty_id,
+      SUM(le.advance_amount) AS advance_amount,
+      SUM(le.settlement_amount) AS settlement_amount
+    FROM ledger_entries le
+    GROUP BY le.subject_id, le.counterparty_id
+  )
+  SELECT
+    a.subject_id,
+    subject_profile.name,
+    a.counterparty_id,
+    counterparty_profile.name,
+    a.advance_amount + a.settlement_amount AS amount,
+    (
+      (a.advance_amount = 0 AND a.settlement_amount <> 0) OR
+      (a.advance_amount * (a.advance_amount + a.settlement_amount) < 0)
+    ) AS is_over_settled
+  FROM aggregated a
+  JOIN public.household_members subject_member
+    ON subject_member.household_id = target_household
+   AND subject_member.user_id = a.subject_id
+  LEFT JOIN public.profiles subject_profile ON subject_profile.id = a.subject_id
+  LEFT JOIN public.profiles counterparty_profile ON counterparty_profile.id = a.counterparty_id
+  WHERE a.advance_amount + a.settlement_amount <> 0
+  ORDER BY subject_member.joined_at, a.counterparty_id NULLS FIRST;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_balance_settlement(
+  target_household UUID,
+  target_subject_user UUID,
+  target_counterparty_user UUID,
+  target_amount NUMERIC,
+  target_settled_on DATE,
+  target_note TEXT DEFAULT NULL
+)
+RETURNS SETOF public.settlements
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_balance NUMERIC;
+  resolved_from_user UUID;
+  resolved_to_user UUID;
+BEGIN
+  IF auth.uid() IS NULL OR NOT public.is_household_member(target_household) THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  IF target_amount IS NULL OR target_amount <= 0 THEN
+    RAISE EXCEPTION 'Settlement amount must be greater than zero';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.household_members hm
+    WHERE hm.household_id = target_household
+      AND hm.user_id = target_subject_user
+  ) THEN
+    RAISE EXCEPTION 'Settlement subject is not a household member';
+  END IF;
+
+  IF target_counterparty_user IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.household_members hm
+    WHERE hm.household_id = target_household
+      AND hm.user_id = target_counterparty_user
+  ) THEN
+    RAISE EXCEPTION 'Settlement counterparty is not a household member';
+  END IF;
+
+  IF target_subject_user = target_counterparty_user THEN
+    RAISE EXCEPTION 'Cannot settle with the same member';
+  END IF;
+
+  -- 同じ残高に対する同時精算を直列化する。
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(
+      target_household::TEXT || ':' ||
+      LEAST(target_subject_user::TEXT, COALESCE(target_counterparty_user::TEXT, 'household')) || ':' ||
+      GREATEST(target_subject_user::TEXT, COALESCE(target_counterparty_user::TEXT, 'household')),
+      0
+    )
+  );
+
+  SELECT breakdown.balance_amount
+  INTO current_balance
+  FROM public.get_household_balance_breakdown(target_household) breakdown
+  WHERE breakdown.subject_user_id = target_subject_user
+    AND breakdown.counterparty_user_id IS NOT DISTINCT FROM target_counterparty_user;
+
+  IF current_balance IS NULL OR current_balance = 0 THEN
+    RAISE EXCEPTION 'There is no outstanding balance to settle';
+  END IF;
+
+  IF target_amount > ABS(current_balance) THEN
+    RAISE EXCEPTION 'Settlement amount exceeds the outstanding balance';
+  END IF;
+
+  IF current_balance > 0 THEN
+    resolved_from_user := target_counterparty_user;
+    resolved_to_user := target_subject_user;
+  ELSE
+    resolved_from_user := target_subject_user;
+    resolved_to_user := target_counterparty_user;
+  END IF;
+
+  RETURN QUERY
+  INSERT INTO public.settlements (
+    household_id,
+    from_user_id,
+    to_user_id,
+    amount,
+    settled_on,
+    note,
+    created_by
+  ) VALUES (
+    target_household,
+    resolved_from_user,
+    resolved_to_user,
+    target_amount,
+    target_settled_on,
+    NULLIF(BTRIM(target_note), ''),
+    auth.uid()
+  )
+  RETURNING *;
+END;
+$$;
+
+-- 新規・更新データに世帯外ユーザーが混ざることを防ぐ。
+CREATE OR REPLACE FUNCTION public.validate_household_participants()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  participant UUID;
+BEGIN
+  IF TG_TABLE_NAME = 'transactions' THEN
+    FOREACH participant IN ARRAY ARRAY[NEW.payer_user_id, NEW.advance_to_user_id]
+    LOOP
+      IF participant IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM public.household_members hm
+        WHERE hm.household_id = NEW.household_id AND hm.user_id = participant
+      ) THEN
+        RAISE EXCEPTION 'Transaction participant is not a household member';
+      END IF;
+    END LOOP;
+  ELSE
+    FOREACH participant IN ARRAY ARRAY[NEW.from_user_id, NEW.to_user_id]
+    LOOP
+      IF participant IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM public.household_members hm
+        WHERE hm.household_id = NEW.household_id AND hm.user_id = participant
+      ) THEN
+        RAISE EXCEPTION 'Settlement participant is not a household member';
+      END IF;
+    END LOOP;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- RPCを経由しないINSERTでも、現在残高・方向・上限を検証する。
+CREATE OR REPLACE FUNCTION public.validate_settlement_against_balance()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  subject_user UUID;
+  counterparty_user UUID;
+  current_balance NUMERIC;
+BEGIN
+  IF NEW.from_user_id IS NULL THEN
+    subject_user := NEW.to_user_id;
+    counterparty_user := NULL;
+  ELSIF NEW.to_user_id IS NULL THEN
+    subject_user := NEW.from_user_id;
+    counterparty_user := NULL;
+  ELSE
+    subject_user := NEW.to_user_id;
+    counterparty_user := NEW.from_user_id;
+  END IF;
+
+  IF subject_user IS NULL THEN
+    RAISE EXCEPTION 'Settlement subject is required';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(
+      NEW.household_id::TEXT || ':' ||
+      LEAST(subject_user::TEXT, COALESCE(counterparty_user::TEXT, 'household')) || ':' ||
+      GREATEST(subject_user::TEXT, COALESCE(counterparty_user::TEXT, 'household')),
+      0
+    )
+  );
+
+  SELECT breakdown.balance_amount
+  INTO current_balance
+  FROM public.get_household_balance_breakdown(NEW.household_id) breakdown
+  WHERE breakdown.subject_user_id = subject_user
+    AND breakdown.counterparty_user_id IS NOT DISTINCT FROM counterparty_user;
+
+  IF current_balance IS NULL OR current_balance = 0 THEN
+    RAISE EXCEPTION 'There is no outstanding balance to settle';
+  END IF;
+
+  IF NEW.amount > ABS(current_balance) THEN
+    RAISE EXCEPTION 'Settlement amount exceeds the outstanding balance';
+  END IF;
+
+  IF NEW.from_user_id IS NULL AND current_balance < 0 THEN
+    RAISE EXCEPTION 'Settlement direction does not match the outstanding balance';
+  ELSIF NEW.to_user_id IS NULL AND current_balance > 0 THEN
+    RAISE EXCEPTION 'Settlement direction does not match the outstanding balance';
+  ELSIF NEW.from_user_id IS NOT NULL AND NEW.to_user_id IS NOT NULL AND current_balance < 0 THEN
+    RAISE EXCEPTION 'Settlement direction does not match the outstanding balance';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS validate_transaction_participants ON public.transactions;
+CREATE TRIGGER validate_transaction_participants
+  BEFORE INSERT OR UPDATE OF household_id, payer_user_id, advance_to_user_id
+  ON public.transactions
+  FOR EACH ROW EXECUTE FUNCTION public.validate_household_participants();
+
+DROP TRIGGER IF EXISTS validate_settlement_participants ON public.settlements;
+CREATE TRIGGER validate_settlement_participants
+  BEFORE INSERT OR UPDATE OF household_id, from_user_id, to_user_id
+  ON public.settlements
+  FOR EACH ROW EXECUTE FUNCTION public.validate_household_participants();
+
+DROP TRIGGER IF EXISTS validate_settlement_balance ON public.settlements;
+CREATE TRIGGER validate_settlement_balance
+  BEFORE INSERT ON public.settlements
+  FOR EACH ROW EXECUTE FUNCTION public.validate_settlement_against_balance();
+
+GRANT EXECUTE ON FUNCTION public.get_household_balance_breakdown(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_balance_settlement(UUID, UUID, UUID, NUMERIC, DATE, TEXT) TO authenticated;
+
+COMMIT;

--- a/supabase/sql/011_recurring_reminder_completion.sql
+++ b/supabase/sql/011_recurring_reminder_completion.sql
@@ -1,0 +1,384 @@
+-- 011_recurring_reminder_completion.sql
+-- 定期設定と取引を直接関連付け、月次のリマインダー非表示を永続化する。
+
+BEGIN;
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS recurring_expense_id UUID
+    REFERENCES public.recurring_expenses(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS recurring_income_id UUID
+    REFERENCES public.recurring_incomes(id) ON DELETE SET NULL;
+
+ALTER TABLE public.transactions
+  DROP CONSTRAINT IF EXISTS transactions_single_recurring_source_check,
+  ADD CONSTRAINT transactions_single_recurring_source_check
+    CHECK (NUM_NONNULLS(recurring_expense_id, recurring_income_id) <= 1),
+  DROP CONSTRAINT IF EXISTS transactions_recurring_expense_type_check,
+  ADD CONSTRAINT transactions_recurring_expense_type_check
+    CHECK (recurring_expense_id IS NULL OR type = 'expense'),
+  DROP CONSTRAINT IF EXISTS transactions_recurring_income_type_check,
+  ADD CONSTRAINT transactions_recurring_income_type_check
+    CHECK (recurring_income_id IS NULL OR type = 'income');
+
+-- 定期設定の参照先が取引と同じ世帯であることを保証する。
+CREATE OR REPLACE FUNCTION public.validate_recurring_transaction_source()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.recurring_expense_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.recurring_expenses re
+    WHERE re.id = NEW.recurring_expense_id AND re.household_id = NEW.household_id
+  ) THEN
+    RAISE EXCEPTION 'Recurring expense does not belong to the transaction household';
+  END IF;
+
+  IF NEW.recurring_income_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.recurring_incomes ri
+    WHERE ri.id = NEW.recurring_income_id AND ri.household_id = NEW.household_id
+  ) THEN
+    RAISE EXCEPTION 'Recurring income does not belong to the transaction household';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS validate_transaction_recurring_source ON public.transactions;
+CREATE TRIGGER validate_transaction_recurring_source
+  BEFORE INSERT OR UPDATE OF household_id, type, recurring_expense_id, recurring_income_id
+  ON public.transactions
+  FOR EACH ROW EXECUTE FUNCTION public.validate_recurring_transaction_source();
+
+CREATE UNIQUE INDEX IF NOT EXISTS transactions_recurring_expense_month_uidx
+  ON public.transactions (recurring_expense_id, DATE_TRUNC('month', occurred_on::timestamp))
+  WHERE recurring_expense_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS transactions_recurring_income_month_uidx
+  ON public.transactions (recurring_income_id, DATE_TRUNC('month', occurred_on::timestamp))
+  WHERE recurring_income_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.recurring_reminder_dismissals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  recurring_expense_id UUID REFERENCES public.recurring_expenses(id) ON DELETE CASCADE,
+  recurring_income_id UUID REFERENCES public.recurring_incomes(id) ON DELETE CASCADE,
+  period_month DATE NOT NULL,
+  dismissed_by UUID NOT NULL REFERENCES auth.users(id),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  CHECK (NUM_NONNULLS(recurring_expense_id, recurring_income_id) = 1),
+  CHECK (period_month = DATE_TRUNC('month', period_month)::date)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS recurring_expense_dismissal_month_uidx
+  ON public.recurring_reminder_dismissals (recurring_expense_id, period_month)
+  WHERE recurring_expense_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS recurring_income_dismissal_month_uidx
+  ON public.recurring_reminder_dismissals (recurring_income_id, period_month)
+  WHERE recurring_income_id IS NOT NULL;
+
+ALTER TABLE public.recurring_reminder_dismissals ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Household members can view reminder dismissals" ON public.recurring_reminder_dismissals;
+CREATE POLICY "Household members can view reminder dismissals"
+  ON public.recurring_reminder_dismissals FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.recurring_expenses re
+      WHERE re.id = recurring_expense_id AND public.is_household_member(re.household_id)
+    ) OR EXISTS (
+      SELECT 1 FROM public.recurring_incomes ri
+      WHERE ri.id = recurring_income_id AND public.is_household_member(ri.household_id)
+    )
+  );
+
+DROP POLICY IF EXISTS "Household members can create reminder dismissals" ON public.recurring_reminder_dismissals;
+CREATE POLICY "Household members can create reminder dismissals"
+  ON public.recurring_reminder_dismissals FOR INSERT
+  WITH CHECK (
+    auth.uid() = dismissed_by AND (
+      EXISTS (
+        SELECT 1 FROM public.recurring_expenses re
+        WHERE re.id = recurring_expense_id AND public.is_household_member(re.household_id)
+      ) OR EXISTS (
+        SELECT 1 FROM public.recurring_incomes ri
+        WHERE ri.id = recurring_income_id AND public.is_household_member(ri.household_id)
+      )
+    )
+  );
+
+GRANT SELECT, INSERT, DELETE ON public.recurring_reminder_dismissals TO authenticated;
+
+-- 一意に対応できる既存取引だけを保守的に関連付ける。
+WITH candidates AS (
+  SELECT
+    t.id AS transaction_id,
+    MIN(re.id::TEXT)::UUID AS recurring_id,
+    t.occurred_on,
+    t.created_at
+  FROM public.transactions t
+  JOIN public.recurring_expenses re
+    ON re.household_id = t.household_id
+   AND t.type = 'expense'
+   AND re.amount = t.amount
+   AND re.category = t.category
+   AND re.payer_user_id = t.payer_user_id
+   AND re.note IS NOT DISTINCT FROM t.note
+   AND t.occurred_on = (
+     DATE_TRUNC('month', t.occurred_on) +
+     (
+       LEAST(
+         re.day_of_month,
+         EXTRACT(DAY FROM (DATE_TRUNC('month', t.occurred_on) + INTERVAL '1 month' - INTERVAL '1 day'))::INTEGER
+       ) - 1
+     ) * INTERVAL '1 day'
+   )::DATE
+  WHERE t.recurring_expense_id IS NULL
+  GROUP BY t.id, t.occurred_on, t.created_at
+  HAVING COUNT(*) = 1
+), ranked AS (
+  SELECT
+    candidates.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY recurring_id, DATE_TRUNC('month', occurred_on::timestamp)
+      ORDER BY occurred_on, created_at, transaction_id
+    ) AS occurrence_rank
+  FROM candidates
+)
+UPDATE public.transactions t
+SET recurring_expense_id = ranked.recurring_id
+FROM ranked
+WHERE t.id = ranked.transaction_id AND ranked.occurrence_rank = 1;
+
+WITH candidates AS (
+  SELECT
+    t.id AS transaction_id,
+    MIN(ri.id::TEXT)::UUID AS recurring_id,
+    t.occurred_on,
+    t.created_at
+  FROM public.transactions t
+  JOIN public.recurring_incomes ri
+    ON ri.household_id = t.household_id
+   AND t.type = 'income'
+   AND ri.amount = t.amount
+   AND ri.category = t.category
+   AND ri.recipient_user_id = t.payer_user_id
+   AND ri.note IS NOT DISTINCT FROM t.note
+   AND t.occurred_on = (
+     DATE_TRUNC('month', t.occurred_on) +
+     (
+       LEAST(
+         ri.day_of_month,
+         EXTRACT(DAY FROM (DATE_TRUNC('month', t.occurred_on) + INTERVAL '1 month' - INTERVAL '1 day'))::INTEGER
+       ) - 1
+     ) * INTERVAL '1 day'
+   )::DATE
+  WHERE t.recurring_income_id IS NULL
+  GROUP BY t.id, t.occurred_on, t.created_at
+  HAVING COUNT(*) = 1
+), ranked AS (
+  SELECT
+    candidates.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY recurring_id, DATE_TRUNC('month', occurred_on::timestamp)
+      ORDER BY occurred_on, created_at, transaction_id
+    ) AS occurrence_rank
+  FROM candidates
+)
+UPDATE public.transactions t
+SET recurring_income_id = ranked.recurring_id
+FROM ranked
+WHERE t.id = ranked.transaction_id AND ranked.occurrence_rank = 1;
+
+CREATE OR REPLACE FUNCTION public.generate_fixed_transactions_by_date(
+  target_household UUID,
+  target_date DATE DEFAULT CURRENT_DATE
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  generated_count INTEGER := 0;
+  recurring_record RECORD;
+  transaction_date DATE;
+  last_day_of_month INTEGER;
+BEGIN
+  IF NOT public.is_household_member(target_household) THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  last_day_of_month := EXTRACT(DAY FROM (
+    DATE_TRUNC('month', target_date) + INTERVAL '1 month' - INTERVAL '1 day'
+  ));
+
+  FOR recurring_record IN
+    SELECT * FROM public.recurring_expenses
+    WHERE household_id = target_household AND is_active = true AND expense_type = 'fixed'
+  LOOP
+    transaction_date := (
+      DATE_TRUNC('month', target_date) +
+      (LEAST(recurring_record.day_of_month, last_day_of_month) - 1) * INTERVAL '1 day'
+    )::DATE;
+
+    IF transaction_date <= target_date AND NOT EXISTS (
+      SELECT 1 FROM public.transactions t
+      WHERE t.recurring_expense_id = recurring_record.id
+        AND t.occurred_on >= DATE_TRUNC('month', target_date)::date
+        AND t.occurred_on < (DATE_TRUNC('month', target_date) + INTERVAL '1 month')::date
+    ) THEN
+      INSERT INTO public.transactions (
+        household_id, type, amount, occurred_on, category, note,
+        payer_user_id, recurring_expense_id, created_by
+      ) VALUES (
+        target_household, 'expense', recurring_record.amount, transaction_date,
+        recurring_record.category, recurring_record.note,
+        recurring_record.payer_user_id, recurring_record.id, auth.uid()
+      );
+      generated_count := generated_count + 1;
+    END IF;
+  END LOOP;
+
+  RETURN generated_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.generate_recurring_transactions(
+  target_household UUID,
+  target_month TEXT
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  generated_count INTEGER := 0;
+  recurring_record RECORD;
+  transaction_date DATE;
+  month_start DATE;
+  next_month_start DATE;
+  last_day_of_month INTEGER;
+BEGIN
+  IF NOT public.is_household_member(target_household) THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  month_start := DATE_TRUNC('month', TO_DATE(target_month, 'YYYY-MM'))::date;
+  next_month_start := (month_start + INTERVAL '1 month')::date;
+  last_day_of_month := EXTRACT(DAY FROM (next_month_start - INTERVAL '1 day'));
+
+  FOR recurring_record IN
+    SELECT * FROM public.recurring_expenses
+    WHERE household_id = target_household AND is_active = true AND expense_type = 'fixed'
+  LOOP
+    transaction_date := (
+      month_start + (LEAST(recurring_record.day_of_month, last_day_of_month) - 1) * INTERVAL '1 day'
+    )::date;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM public.transactions t
+      WHERE t.recurring_expense_id = recurring_record.id
+        AND t.occurred_on >= month_start AND t.occurred_on < next_month_start
+    ) THEN
+      INSERT INTO public.transactions (
+        household_id, type, amount, occurred_on, category, note,
+        payer_user_id, recurring_expense_id, created_by
+      ) VALUES (
+        target_household, 'expense', recurring_record.amount, transaction_date,
+        recurring_record.category, recurring_record.note,
+        recurring_record.payer_user_id, recurring_record.id, auth.uid()
+      );
+      generated_count := generated_count + 1;
+    END IF;
+  END LOOP;
+
+  RETURN generated_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_variable_expense_reminders(
+  target_household UUID,
+  target_date DATE DEFAULT CURRENT_DATE
+)
+RETURNS TABLE (
+  id UUID, amount NUMERIC, day_of_month INTEGER, category TEXT,
+  note TEXT, payer_user_id UUID
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  month_start DATE := DATE_TRUNC('month', target_date)::date;
+  next_month_start DATE := (DATE_TRUNC('month', target_date) + INTERVAL '1 month')::date;
+BEGIN
+  IF NOT public.is_household_member(target_household) THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT re.id, re.amount, re.day_of_month, re.category, re.note, re.payer_user_id
+  FROM public.recurring_expenses re
+  WHERE re.household_id = target_household
+    AND re.is_active = true
+    AND re.expense_type = 'variable'
+    AND re.day_of_month <= EXTRACT(DAY FROM target_date)
+    AND NOT EXISTS (
+      SELECT 1 FROM public.transactions t
+      WHERE t.recurring_expense_id = re.id
+        AND t.occurred_on >= month_start AND t.occurred_on < next_month_start
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.recurring_reminder_dismissals d
+      WHERE d.recurring_expense_id = re.id AND d.period_month = month_start
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_income_reminders(
+  target_household UUID,
+  target_date DATE DEFAULT CURRENT_DATE
+)
+RETURNS TABLE (
+  id UUID, amount NUMERIC, day_of_month INTEGER, category TEXT,
+  note TEXT, recipient_user_id UUID
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  month_start DATE := DATE_TRUNC('month', target_date)::date;
+  next_month_start DATE := (DATE_TRUNC('month', target_date) + INTERVAL '1 month')::date;
+BEGIN
+  IF NOT public.is_household_member(target_household) THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT ri.id, ri.amount, ri.day_of_month, ri.category, ri.note, ri.recipient_user_id
+  FROM public.recurring_incomes ri
+  WHERE ri.household_id = target_household
+    AND ri.is_active = true
+    AND ri.day_of_month <= EXTRACT(DAY FROM target_date)
+    AND NOT EXISTS (
+      SELECT 1 FROM public.transactions t
+      WHERE t.recurring_income_id = ri.id
+        AND t.occurred_on >= month_start AND t.occurred_on < next_month_start
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.recurring_reminder_dismissals d
+      WHERE d.recurring_income_id = ri.id AND d.period_month = month_start
+    );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.generate_fixed_transactions_by_date(UUID, DATE) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.generate_recurring_transactions(UUID, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_variable_expense_reminders(UUID, DATE) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_income_reminders(UUID, DATE) TO authenticated;
+
+COMMIT;

--- a/supabase/sql/012_ranked_place_suggestions.sql
+++ b/supabase/sql/012_ranked_place_suggestions.sql
@@ -1,0 +1,41 @@
+-- 012_ranked_place_suggestions.sql
+-- 場所候補を最終利用日・利用回数付きで返す。
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_ranked_place_suggestions(
+  target_household UUID
+)
+RETURNS TABLE (
+  place TEXT,
+  use_count BIGINT,
+  last_used_on DATE
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.is_household_member(target_household) THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    BTRIM(t.place) AS place,
+    COUNT(*) AS use_count,
+    MAX(t.occurred_on) AS last_used_on
+  FROM public.transactions t
+  WHERE t.household_id = target_household
+    AND t.place IS NOT NULL
+    AND BTRIM(t.place) <> ''
+  GROUP BY BTRIM(t.place)
+  ORDER BY MAX(t.occurred_on) DESC, COUNT(*) DESC, BTRIM(t.place)
+  LIMIT 100;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_ranked_place_suggestions(UUID) TO authenticated;
+
+COMMIT;

--- a/supabase/sql/README.md
+++ b/supabase/sql/README.md
@@ -6,6 +6,9 @@
 | `001_create_household_module.sql` | テーブル・関数・RLS ポリシーを一括作成します。`000` 実行後に流してください。 |
 | `002_update_household_owner_policy.sql` | owner_user_id の自動上書きと households INSERT ポリシー調整。`001` 適用済み環境向け。 |
 | `003_grant_household_permissions.sql` | households ドメインのテーブル権限を authenticated ロールへ付与します。 |
+| `010_balance_breakdown_and_safe_settlement.sql` | 世帯向け・家族間の立替残高明細と、過剰精算を防ぐ精算 RPC を追加します。 |
+| `011_recurring_reminder_completion.sql` | 定期設定と取引の関連、月次リマインダー非表示を追加します。 |
+| `012_ranked_place_suggestions.sql` | 利用回数・最終利用日で並べた場所候補 RPC を追加します。 |
 
 実行手順（Supabase SQL Editor）:
 1. ローカルで内容を確認し、必要に応じて編集。
@@ -14,5 +17,7 @@
 4. 既に `001` を流した環境にポリシー調整が必要な場合は `002_update_household_owner_policy.sql` を追加で実行。
 5. households 関連テーブルの権限を再付与するため `003_grant_household_permissions.sql` を実行。
 6. ローカルでは `supabase db remote commit` / `supabase db push --dry-run` などで差分確認。
+
+`010`〜`012` は既存データを削除せず、番号順に適用してください。Web アプリは3ファイルの適用後に展開します。
 
 アーカイブ済みの旧スクリプトは `archive/` ディレクトリに保管しています。長期的に不要であれば削除してください。


### PR DESCRIPTION
## 概要

実利用で確認された立替精算、定期リマインダー、モバイル入力、場所候補の問題を修正します。あわせて、ローカル専用のテストログインと確認データseedを追加します。

## 主な変更

- 世帯向けと家族間の立替残高を相手別明細へ分離
- 家族分の代理精算、部分精算、過剰精算のサーバー側検証を追加
- 定期支出・定期収入リマインダーの完了と月次非表示を永続化
- iPhone向け取引ボトムシートと44px以上の操作領域を実装
- 「登録して続ける」と検索可能な場所コンボボックスを追加
- 重い画面の遅延ロードと重複エラー通知の整理
- ローカル開発専用テストログインとテストデータseedを追加
- Supabase SQL 010〜012とWebKit E2E・回帰テストを追加

## DB変更

Supabase SQL 010、011、012を番号順に適用します。既存の金融履歴は削除・自動補正しません。公開対象のSupabaseには適用済みです。

## 本番環境の注意

`NEXT_PUBLIC_ENABLE_DEV_LOGIN`と`NEXT_PUBLIC_DEV_LOGIN_*`はVercel本番環境へ設定しません。未設定ならテストログインUIと資格情報は本番ビルドに含まれません。

## 検証

- `pnpm --filter web test`: 41件成功
- `pnpm --filter web lint`: 成功
- `pnpm --filter web type-check`: 成功
- `pnpm --filter web build`: 成功
- iPhone 13相当WebKit E2E: 成功
- 実機ローカル確認: 成功
